### PR TITLE
Enable builds and publishing with DevZone from git source

### DIFF
--- a/.devzone/build/jenkins_build.sh
+++ b/.devzone/build/jenkins_build.sh
@@ -3,14 +3,19 @@
 # Make sure we fail on failed regression tests
 set -e
 
-BRANCH="$BRANCH-"
-if [ "$BRANCH" == "default-" ]; then BRANCH=""; fi
-REV="v`~/bin/getdays2000`"
-REV="$BRANCH$REV"
-if [ "$BUILD_TYPE" == "releases" ]; then REV="$USE_REV"; fi
-
 # Use the revision we're asked to build:
-hg up $USE_REV
+if [ "USE_REV" != "HEAD" ]; then
+    git checkout $USE_REV
+else
+    git checkout $BRANCH
+fi
+
+VSTRING = $(python3 nml/version_info.py)
+HASH = echo "$VSTRING" | cut -d\; -f1
+BRANCH = echo "$VSTRING" | cut -d\; -f2
+TAG = echo "$VSTRING" | cut -d\; -f3
+MODIFIED = echo "$VSTRING" | cut -d\; -f4
+DATE = echo "$VSTRING" | cut -d\; -f5
 
 # Check regressions
 make -j1 regression
@@ -52,6 +57,8 @@ cd ..
 ./gen_editor notepadpp
 mv *.xml dist
 
-echo "Build date: `date --rfc-3339='seconds'`" > dist/release.txt
-echo "Revision: `hg id -n`:`hg id`" >> dist/release.txt
+echo "Build date: $DATE"        > dist/release.txt
+echo "Revision: $BRANCH-$HASH" >> dist/release.txt
+echo "Tag: $TAG"               >> dist/release.txt
+echo "Modified: $MODIFIED"     >> dist/release.txt"
 

--- a/.devzone/build/jenkins_build.sh
+++ b/.devzone/build/jenkins_build.sh
@@ -60,5 +60,5 @@ mv *.xml dist
 echo "Build date: $DATE"        > dist/release.txt
 echo "Revision: $BRANCH-$HASH" >> dist/release.txt
 echo "Tag: $TAG"               >> dist/release.txt
-echo "Modified: $MODIFIED"     >> dist/release.txt"
+echo "Modified: $MODIFIED"     >> dist/release.txt
 

--- a/.devzone/build/jenkins_build.sh
+++ b/.devzone/build/jenkins_build.sh
@@ -10,12 +10,12 @@ else
     git checkout $BRANCH
 fi
 
-VSTRING = $(python3 nml/version_info.py)
-HASH = echo "$VSTRING" | cut -d\; -f1
-BRANCH = echo "$VSTRING" | cut -d\; -f2
-TAG = echo "$VSTRING" | cut -d\; -f3
-MODIFIED = echo "$VSTRING" | cut -d\; -f4
-DATE = echo "$VSTRING" | cut -d\; -f5
+VSTRING= $(python3 nml/version_info.py)
+HASH= echo "$VSTRING" | cut -d\; -f1
+BRANCH= echo "$VSTRING" | cut -d\; -f2
+TAG= echo "$VSTRING" | cut -d\; -f3
+MODIFIED= echo "$VSTRING" | cut -d\; -f4
+DATE= echo "$VSTRING" | cut -d\; -f5
 
 # Check regressions
 make -j1 regression

--- a/.devzone/build/jenkins_build.sh
+++ b/.devzone/build/jenkins_build.sh
@@ -10,12 +10,12 @@ else
     git checkout $BRANCH
 fi
 
-VSTRING= $(python3 nml/version_info.py)
-HASH= echo "$VSTRING" | cut -d\; -f1
-BRANCH= echo "$VSTRING" | cut -d\; -f2
-TAG= echo "$VSTRING" | cut -d\; -f3
-MODIFIED= echo "$VSTRING" | cut -d\; -f4
-DATE= echo "$VSTRING" | cut -d\; -f5
+VSTRING="$(python3 nml/version_info.py)"
+HASH="$(echo $VSTRING | cut -d\; -f1)"
+BRANCH="$(echo $VSTRING | cut -d\; -f2)"
+TAG="$(echo $VSTRING | cut -d\; -f3)"
+MODIFIED="$(echo $VSTRING | cut -d\; -f4)"
+DATE="$(echo $VSTRING | cut -d\; -f5)"
 
 # Check regressions
 make -j1 regression

--- a/.devzone/build/jenkins_build.sh
+++ b/.devzone/build/jenkins_build.sh
@@ -16,6 +16,7 @@ BRANCH="$(echo $VSTRING | cut -d\; -f2)"
 TAG="$(echo $VSTRING | cut -d\; -f3)"
 MODIFIED="$(echo $VSTRING | cut -d\; -f4)"
 DATE="$(echo $VSTRING | cut -d\; -f5)"
+REV="$(echo $VSTRING | cut -d\; -f6)"
 
 # Check regressions
 make -j1 regression

--- a/nml/version_info.py
+++ b/nml/version_info.py
@@ -130,7 +130,7 @@ def get_git_version(detailed = False):
             version += "M"
 
         if detailed:
-            version = changeset + ";" + branch + ";" + str_tag + ";" + str(modified) + ";" + isodate
+            version = changeset + ";" + branch + ";" + str_tag + ";" + str(modified) + ";" + isodate + ";" + version
 
     return version
 

--- a/nml/version_info.py
+++ b/nml/version_info.py
@@ -78,7 +78,7 @@ def get_hg_version():
             version = "v{}{}:{} from {}".format(cversion, modified, hash, ctimes[2].split("'", 1)[0])
     return version
 
-def get_git_version():
+def get_git_version(detailed = False):
     # method adopted shamelessly from OpenTTD's findversion.sh
     path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
     version = ''
@@ -117,8 +117,10 @@ def get_git_version():
             pass
 
         # Compose the actual version string
+        str_tag = ""
         if len(tag) > 0:
             version = tag[0]
+            str_tag = tag[0]
         elif branch == "master":
             version = isodate + "-g" + changeset
         else:
@@ -126,6 +128,9 @@ def get_git_version():
 
         if modified:
             version += "M"
+
+        if detailed:
+            version = changeset + ";" + branch + ";" + str_tag + ";" + str(modified) + ";" + isodate
 
     return version
 
@@ -186,4 +191,4 @@ def get_and_write_version():
             print("Version file NOT written")
 
 if __name__ == '__main__':
-    print(get_git_version())
+    print(get_git_version(detailed=True))


### PR DESCRIPTION
nml is so far not published when built from sources and neither are DevZone's nml versions used for building NewGRFs updated  when a new version is pushed.