### PR TITLE
Feature: increase railtype ID range from 16 to 64, to support 64 rail…

### DIFF
--- a/nml/actions/action0.py
+++ b/nml/actions/action0.py
@@ -202,7 +202,7 @@ used_ids = [
     BlockAllocation(  0,    127, "Airport"),
     BlockAllocation(  0,     -1, "Signal", False),
     BlockAllocation(  0,    255, "Object"),
-    BlockAllocation(  0,     15, "Railtype"),
+    BlockAllocation(  0,     63, "Railtype"),
     BlockAllocation(  0,    255, "Airport Tile"),
 ]
 


### PR DESCRIPTION
…types

in Openttd bf8d7df7367055dcfad6cc1c21fd9c762ffc2fe4