### PR TITLE
Fix: Allow access to towns as parent object

### DIFF
--- a/nml/actions/action0properties.py
+++ b/nml/actions/action0properties.py
@@ -16,6 +16,7 @@ with NML; if not, write to the Free Software Foundation, Inc.,
 import itertools
 from nml import generic, nmlop
 from nml.expression import BinOp, ConstantNumeric, ConstantFloat, Array, StringLiteral, Identifier, ProduceCargo, AcceptCargo
+from nml.ast.general import feature_ids as fids
 
 tilelayout_names = {}
 
@@ -151,7 +152,7 @@ class Action0Property(BaseAction0Property):
 #
 # 'first' (value doesn't matter) if the property should be set first (generally a substitute type)
 
-properties = 0x12 * [None]
+properties = len(fids) * [None]
 
 #
 # Some helper functions that are used for multiple features
@@ -303,7 +304,7 @@ def zero_refit_mask(prop_num):
 # Feature 0x00 (Trains)
 #
 
-properties[0x00] = {
+properties[fids['FEAT_TRAINS']] = {
     'track_type'                   : {'size': 1, 'num': 0x05},
     'ai_special_flag'              : {'size': 1, 'num': 0x08},
     'speed'                        : {'size': 2, 'num': 0x09, 'unit_type': 'speed', 'unit_conversion': (5000, 1397), 'adjust_value': lambda val, unit: ottd_display_speed(val, 1, unit)},
@@ -344,7 +345,7 @@ properties[0x00] = {
     'cargo_allow_refit'            : [{'custom_function': lambda value: ctt_list(0x2C, value)}, zero_refit_mask(0x1D)],
     'cargo_disallow_refit'         : [{'custom_function': lambda value: ctt_list(0x2D, value)}, zero_refit_mask(0x1D)],
 }
-properties[0x00].update(general_veh_props)
+properties[fids['FEAT_TRAINS']].update(general_veh_props)
 
 #
 # Feature 0x01 (Road Vehicles)
@@ -363,7 +364,7 @@ def roadveh_speed_prop(prop_info):
         prop08[key] = prop15[key] = prop_info[key]
     return [prop08, prop15]
 
-properties[0x01] = {
+properties[fids['FEAT_ROADVEHS']] = {
     'speed'                        : roadveh_speed_prop({'unit_type': 'speed', 'unit_conversion': (10000, 1397), 'adjust_value': lambda val, unit: ottd_display_speed(val, 2, unit)}),
     'running_cost_factor'          : {'size': 1, 'num': 0x09},
     'running_cost_base'            : {'size': 4, 'num': 0x0A},
@@ -395,7 +396,7 @@ properties[0x01] = {
     'cargo_allow_refit'            : [{'custom_function': lambda value: ctt_list(0x24, value)}, zero_refit_mask(0x16)],
     'cargo_disallow_refit'         : [{'custom_function': lambda value: ctt_list(0x25, value)}, zero_refit_mask(0x16)],
 }
-properties[0x01].update(general_veh_props)
+properties[fids['FEAT_ROADVEHS']].update(general_veh_props)
 
 #
 # Feature 0x02 (Ships)
@@ -408,7 +409,7 @@ def speed_fraction(value):
         raise generic.ScriptError("speed fraction must be in range 0 .. 1", value.pos)
     return BinOp(nmlop.SUB, ConstantNumeric(255, value.pos), value, value.pos).reduce()
 
-properties[0x02] = {
+properties[fids['FEAT_SHIPS']] = {
     'sprite_id'                    : {'size': 1, 'num': 0x08},
     'is_refittable'                : {'size': 1, 'num': 0x09},
     'cost_factor'                  : {'size': 1, 'num': 0x0A},
@@ -436,7 +437,7 @@ properties[0x02] = {
     'cargo_allow_refit'            : [{'custom_function': lambda value: ctt_list(0x1E, value)}, zero_refit_mask(0x11)],
     'cargo_disallow_refit'         : [{'custom_function': lambda value: ctt_list(0x1F, value)}, zero_refit_mask(0x11)],
 }
-properties[0x02].update(general_veh_props)
+properties[fids['FEAT_SHIPS']].update(general_veh_props)
 
 #
 # Feature 0x03 (Aircraft)
@@ -450,7 +451,7 @@ def aircraft_is_heli(value):
 def aircraft_is_large(value):
     return BinOp(nmlop.AND, value, ConstantNumeric(1, value.pos), value.pos).reduce()
 
-properties[0x03] = {
+properties[fids['FEAT_AIRCRAFT']] = {
     'sprite_id'                    : {'size': 1, 'num': 0x08},
     'aircraft_type'                : [{'size': 1, 'num': 0x09, 'value_function': aircraft_is_heli}, {'size': 1, 'num': 0x0A, 'value_function': aircraft_is_large}],
     'cost_factor'                  : {'size': 1, 'num': 0x0B},
@@ -475,7 +476,7 @@ properties[0x03] = {
     'cargo_disallow_refit'         : [{'custom_function': lambda value: ctt_list(0x1E, value)}, zero_refit_mask(0x13)],
     'range'                        : {'size': 2, 'num': 0x1F},
 }
-properties[0x03].update(general_veh_props)
+properties[fids['FEAT_AIRCRAFT']].update(general_veh_props)
 
 # TODO: Feature 0x04
 
@@ -483,7 +484,7 @@ properties[0x03].update(general_veh_props)
 # Feature 0x05 (Canals)
 #
 
-properties[0x05] = {
+properties[fids['FEAT_CANALS']] = {
     # 08 (callback flags) not set by user
     'graphic_flags'  : {'size': 1, 'num': 0x09},
 }
@@ -635,7 +636,7 @@ def mt_house_class(value, num_ids, size_bit):
     # Set class to 0xFF for additional tiles
     return [value] + (num_ids - 1) * [ConstantNumeric(0xFF, value.pos)]
 
-properties[0x07] = {
+properties[fids['FEAT_HOUSES']] = {
     'substitute'              : {'size': 1, 'num': 0x08, 'multitile_function': mt_house_old_id, 'first': None},
     'building_flags'          : two_byte_property(0x09, 0x19, {'multitile_function': mt_house_prop09}, {'multitile_function': lambda *args: mt_house_mask(0xFE, *args)}),
     'years_available'         : [{'size': 2, 'num': 0x0A, 'multitile_function': mt_house_zero, 'value_function': house_prop_0A},
@@ -690,7 +691,7 @@ def industrytile_cargos(value):
         prop_num += 1
     return props
 
-properties[0x09] = {
+properties[fids['FEAT_INDUSTRYTILES']] = {
     'substitute'         : {'size': 1, 'num': 0x08, 'first': None},
     'override'           : {'size': 1, 'num': 0x09},
     'accepted_cargos'    : {'custom_function': industrytile_cargos}, # = prop 0A - 0C
@@ -867,7 +868,7 @@ def industry_cargo_types(value):
         IndustryInputMultiplierProp(0x28, input_multipliers if has_inpmult else [])
     ]
 
-properties[0x0A] = {
+properties[fids['FEAT_INDUSTRIES']] = {
     'substitute'             : {'size': 1, 'num': 0x08, 'first': None},
     'override'               : {'size': 1, 'num': 0x09},
     'layouts'                : {'custom_function': industry_layouts}, # = prop 0A
@@ -897,7 +898,7 @@ properties[0x0A] = {
 # Feature 0x0B (Cargos)
 #
 
-properties[0x0B] = {
+properties[fids['FEAT_CARGOS']] = {
     'number'                    : {'num' : 0x08, 'size' : 1},
     'type_name'                 : {'num' : 0x09, 'size' : 2, 'string' : 0xDC},
     'unit_name'                 : {'num' : 0x0A, 'size' : 2, 'string' : 0xDC},
@@ -970,7 +971,7 @@ def airport_layouts(value):
         layouts.append(layout)
     return [AirportLayoutProp(layouts)]
 
-properties[0x0D] = {
+properties[fids['FEAT_AIRPORTS']] = {
     'override'         : {'size': 1, 'num': 0x08, 'first':None},
     # 09 does not exist
     'layouts'          : {'custom_function': airport_layouts}, # = prop 0A
@@ -998,7 +999,7 @@ def object_size(value):
         raise generic.ScriptError("The size of an object must be at least 1x1 and at most 15x15 tiles", value.pos)
     return [Action0Property(0x0C, ConstantNumeric(sizey.value << 4 | sizex.value), 1)]
 
-properties[0x0F] = {
+properties[fids['FEAT_OBJECTS']] = {
     'class'                  : {'size': 4, 'num': 0x08, 'first': None, 'string_literal': 4},
     # strings might be according to specs be either 0xD0 or 0xD4
     'classname'              : {'size': 2, 'num': 0x09, 'string': 0xD0},
@@ -1045,7 +1046,7 @@ def railtype_list(value, prop_num):
         if not isinstance(val, StringLiteral): raise generic.ScriptError("Railtype list must be an array of literal strings", val.pos)
     return [RailtypeListProp(prop_num, value.values)]
 
-properties[0x10] = {
+properties[fids['FEAT_RAILTYPES']] = {
     'label'                    : {'size': 4, 'num': 0x08, 'string_literal': 4}, # is allocated during reservation stage, setting label first is thus not needed
     'toolbar_caption'          : {'size': 2, 'num': 0x09, 'string': 0xDC},
     'menu_text'                : {'size': 2, 'num': 0x0A, 'string': 0xDC},
@@ -1074,7 +1075,7 @@ properties[0x10] = {
 # Feature 0x11 (Airport Tiles)
 #
 
-properties[0x11] = {
+properties[fids['FEAT_AIRPORTTILES']] = {
     'substitute'         : {'size': 1, 'num': 0x08, 'first': None},
     'override'           : {'size': 1, 'num': 0x09},
     # 0A - 0D don't exist (yet?)

--- a/nml/actions/action2var.py
+++ b/nml/actions/action2var.py
@@ -16,6 +16,7 @@ with NML; if not, write to the Free Software Foundation, Inc.,
 from nml.actions import action2, action2real, action2var_variables, action4, action6, actionD
 from nml import expression, generic, global_constants, nmlop
 from nml.ast import general
+from nml.ast.general import feature_ids as fids
 
 class Action2Var(action2.Action2):
     """
@@ -404,7 +405,7 @@ class Varaction2Parser(object):
         max = 0xF if expr.info['perm'] else 0x10F
         if isinstance(expr.register, expression.ConstantNumeric) and expr.register.value > max:
             raise generic.ScriptError("Register number must be in range 0..{:d}, encountered {:d}.".format(max, expr.register.value), expr.pos)
-        if expr.info['perm'] and self.feature not in (0x08, 0x0A, 0x0D, 0x12):
+        if expr.info['perm'] and self.feature not in (fids['FEAT_GLOBAL_VARS'], fids['FEAT_INDUSTRIES'], fids['AIRPORTS'], fids['FEAT_GENERIC_PARENT']):
             raise generic.ScriptError("Persistent storage is not supported for feature '{}'".format(general.feature_name(self.feature)), expr.pos)
 
         if expr.info['store']:
@@ -414,7 +415,7 @@ class Varaction2Parser(object):
             var_num = 0x7C if expr.info['perm'] else 0x7D
             ret = expression.Variable(expression.ConstantNumeric(var_num), param=expr.register, pos=expr.pos)
 
-        if expr.info['perm'] and (self.feature == 0x08 or self.feature == 0x12):
+        if expr.info['perm'] and (self.feature == fids['FEAT_GLOBAL_VARS'] or self.feature == fids['FEAT_GENERIC_PARENT']):
             # store grfid in register 0x100 for town persistent storage
             grfid = expression.ConstantNumeric(0xFFFFFFFF if expr.grfid is None else expression.parse_string_to_dword(expr.grfid))
             store_op = expression.BinOp(nmlop.STO_TMP, grfid, expression.ConstantNumeric(0x100), expr.pos)

--- a/nml/actions/action2var.py
+++ b/nml/actions/action2var.py
@@ -404,7 +404,7 @@ class Varaction2Parser(object):
         max = 0xF if expr.info['perm'] else 0x10F
         if isinstance(expr.register, expression.ConstantNumeric) and expr.register.value > max:
             raise generic.ScriptError("Register number must be in range 0..{:d}, encountered {:d}.".format(max, expr.register.value), expr.pos)
-        if expr.info['perm'] and self.feature not in (0x08, 0x0A, 0x0D):
+        if expr.info['perm'] and self.feature not in (0x08, 0x0A, 0x0D, 0x12):
             raise generic.ScriptError("Persistent storage is not supported for feature '{}'".format(general.feature_name(self.feature)), expr.pos)
 
         if expr.info['store']:
@@ -414,7 +414,7 @@ class Varaction2Parser(object):
             var_num = 0x7C if expr.info['perm'] else 0x7D
             ret = expression.Variable(expression.ConstantNumeric(var_num), param=expr.register, pos=expr.pos)
 
-        if expr.info['perm'] and self.feature == 0x08:
+        if expr.info['perm'] and (self.feature == 0x08 or self.feature == 0x12):
             # store grfid in register 0x100 for town persistent storage
             grfid = expression.ConstantNumeric(0xFFFFFFFF if expr.grfid is None else expression.parse_string_to_dword(expr.grfid))
             store_op = expression.BinOp(nmlop.STO_TMP, grfid, expression.ConstantNumeric(0x100), expr.pos)

--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -14,12 +14,33 @@ with NML; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
 from nml import expression, nmlop, generic
+from nml.ast.general import feature_ids as feature
 
-# Use feature 0x12 for towns (accessible via station/house/industry parent scope)
-varact2vars = 0x13 * [{}]
-varact2vars60x = 0x13 * [{}]
-# feature number:      0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12
-varact2parent_scope = [0x00, 0x01, 0x02, 0x03, 0x12, None, 0x12, 0x12, None, 0x0A, 0x12, None, None, None, None, 0x12, None, None, None]
+varact2vars = len(feature) * [{}]
+varact2vars60x = len(feature) * [{}]
+# feature number:  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12
+#                  0x00, 0x01, 0x02, 0x03, 0x12, None, 0x12, 0x12, None, 0x0A, 0x12, None, None, None, None, 0x12, None, None, None]
+varact2parent_scope = [
+        feature['FEAT_TRAINS'],             # 0x00 Trains
+        feature['FEAT_ROADVEHS'],           # 0x01 Road vehicles
+        feature['FEAT_SHIPS'],              # 0x02 Ships
+        feature['FEAT_AIRCRAFT'],           # 0x03 Aircraft
+        feature['FEAT_GENERIC_PARENT'],     # 0x04 Stations
+        None,                               # 0x05 Canals
+        feature['FEAT_GENERIC_PARENT'],     # 0x06 Bridges
+        feature['FEAT_GENERIC_PARENT'],     # 0x07 Houses
+        None,                               # 0x08 Global variables
+        feature['FEAT_INDUSTRIES'],         # 0x09 Industry Tiles
+        feature['FEAT_GENERIC_PARENT'],     # 0x0A Industries
+        None,                               # 0x0B Cargoes
+        None,                               # 0x0C Sound effects
+        None,                               # 0x0D Airports
+        None,                               # 0x0E Signals
+        feature['FEAT_GENERIC_PARENT'],     # 0x0F Objects
+        None,                               # 0x10 Railtypes
+        None,                               # 0x11 Airport Tiles
+        None,                               # 0x12 "Towns" (must always be last)
+        ]
 
 def default_60xvar(name, args, pos, info):
     """
@@ -702,28 +723,28 @@ varact2vars_towns = {
 }
 
 
-varact2vars[0x00] = varact2vars_trains
-varact2vars60x[0x00] = varact2vars60x_vehicles
-varact2vars[0x01] = varact2vars_roadvehs
-varact2vars60x[0x01] = varact2vars60x_vehicles
-varact2vars[0x02] = varact2vars_ships
-varact2vars60x[0x02] = varact2vars60x_vehicles
-varact2vars[0x03] = varact2vars_aircraft
-varact2vars60x[0x03] = varact2vars60x_vehicles
-varact2vars[0x04] = varact2vars_stations
-varact2vars60x[0x04] = varact2vars60x_stations
-varact2vars[0x05] = varact2vars_canals
-varact2vars[0x07] = varact2vars_houses
-varact2vars60x[0x07] = varact2vars60x_houses
-varact2vars[0x09] = varact2vars_industrytiles
-varact2vars60x[0x09] = varact2vars60x_industrytiles
-varact2vars[0x0A] = varact2vars_industries
-varact2vars60x[0x0A] = varact2vars60x_industries
-varact2vars[0x0D] = varact2vars_airports
-varact2vars60x[0x0D] = varact2vars60x_airports
-varact2vars[0x0F] = varact2vars_objects
-varact2vars60x[0x0F] = varact2vars60x_objects
-varact2vars[0x10] = varact2vars_railtype
-varact2vars[0x11] = varact2vars_airporttiles
-varact2vars60x[0x11] = varact2vars60x_airporttiles
-varact2vars[0x12] = varact2vars_towns
+varact2vars[feature['FEAT_TRAINS']] = varact2vars_trains
+varact2vars60x[feature['FEAT_TRAINS']] = varact2vars60x_vehicles
+varact2vars[feature['FEAT_ROADVEHS']] = varact2vars_roadvehs
+varact2vars60x[feature['FEAT_ROADVEHS']] = varact2vars60x_vehicles
+varact2vars[feature['FEAT_SHIPS']] = varact2vars_ships
+varact2vars60x[feature['FEAT_SHIPS']] = varact2vars60x_vehicles
+varact2vars[feature['FEAT_AIRCRAFT']] = varact2vars_aircraft
+varact2vars60x[feature['FEAT_AIRCRAFT']] = varact2vars60x_vehicles
+varact2vars[feature['FEAT_AIRCRAFT']] = varact2vars_stations
+varact2vars60x[feature['FEAT_STATIONS']] = varact2vars60x_stations
+varact2vars[feature['FEAT_CANALS']] = varact2vars_canals
+varact2vars[feature['FEAT_HOUSES']] = varact2vars_houses
+varact2vars60x[feature['FEAT_HOUSES']] = varact2vars60x_houses
+varact2vars[feature['FEAT_INDUSTRYTILES']] = varact2vars_industrytiles
+varact2vars60x[feature['FEAT_INDUSTRYTILES']] = varact2vars60x_industrytiles
+varact2vars[feature['FEAT_INDUSTRIES']] = varact2vars_industries
+varact2vars60x[feature['FEAT_INDUSTRIES']] = varact2vars60x_industries
+varact2vars[feature['FEAT_AIRPORTS']] = varact2vars_airports
+varact2vars60x[feature['FEAT_AIRPORTS']] = varact2vars60x_airports
+varact2vars[feature['FEAT_OBJECTS']] = varact2vars_objects
+varact2vars60x[feature['FEAT_OBJECTS']] = varact2vars60x_objects
+varact2vars[feature['FEAT_RAILTYPES']] = varact2vars_railtype
+varact2vars[feature['FEAT_AIRPORTTILES']] = varact2vars_airporttiles
+varact2vars60x[feature['FEAT_AIRPORTTILES']] = varact2vars60x_airporttiles
+varact2vars[feature['FEAT_GENERIC_PARENT']] = varact2vars_towns

--- a/nml/actions/action3_callbacks.py
+++ b/nml/actions/action3_callbacks.py
@@ -14,8 +14,9 @@ with NML; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
 from nml import expression, nmlop
+from nml.ast.general import feature_ids as fids
 
-callbacks = 0x12 * [{}]
+callbacks = len(fids) * [{}]
 
 # Possible values for 'purchase':
 # 0 (or not set): not called from purchase list
@@ -46,7 +47,7 @@ def vehicle_length(value):
     return expression.BinOp(nmlop.SUB, expression.ConstantNumeric(8, value.pos), value, value.pos)
 
 # Trains
-callbacks[0x00] = {
+callbacks[fids['FEAT_TRAINS']] = {
     'visual_effect_and_powered'            : {'type': 'cb', 'num': 0x10, 'flag_bit': 0},
     'effect_spawn_model_and_powered'       : {'type': 'cb', 'num': 0x10, 'flag_bit': 0},
     'length'                               : {'type': 'cb', 'num': 0x36, 'var10': 0x21, 'value_function': vehicle_length},
@@ -70,10 +71,10 @@ callbacks[0x00] = {
     'cargo_age_period'                     : {'type': 'cb', 'num': 0x36, 'var10': 0x2B},
     'create_effect'                        : {'type': 'cb', 'num': 0x160},
 }
-callbacks[0x00].update(general_vehicle_cbs)
+callbacks[fids['FEAT_TRAINS']].update(general_vehicle_cbs)
 
 # Road vehicles
-callbacks[0x01] = {
+callbacks[fids['FEAT_ROADVEHS']] = {
     'visual_effect'                        : {'type': 'cb', 'num': 0x10, 'flag_bit': 0},
     'effect_spawn_model'                   : {'type': 'cb', 'num': 0x10, 'flag_bit': 0},
     'length'                               : {'type': 'cb', 'num': 0x36, 'var10': 0x23, 'value_function': vehicle_length},
@@ -95,10 +96,10 @@ callbacks[0x01] = {
     'cargo_age_period'                     : {'type': 'cb', 'num': 0x36, 'var10': 0x22},
     'create_effect'                        : {'type': 'cb', 'num': 0x160},
 }
-callbacks[0x01].update(general_vehicle_cbs)
+callbacks[fids['FEAT_ROADVEHS']].update(general_vehicle_cbs)
 
 # Ships
-callbacks[0x02] = {
+callbacks[fids['FEAT_SHIPS']] = {
     'visual_effect'                : {'type': 'cb', 'num': 0x10, 'flag_bit': 0},
     'effect_spawn_model'           : {'type': 'cb', 'num': 0x10, 'flag_bit': 0},
     'cargo_capacity'               : [ {'type': 'cb', 'num': 0x15, 'flag_bit': 3},
@@ -112,10 +113,10 @@ callbacks[0x02] = {
     'cargo_age_period'             : {'type': 'cb', 'num': 0x36, 'var10': 0x1D},
     'create_effect'                : {'type': 'cb', 'num': 0x160},
 }
-callbacks[0x02].update(general_vehicle_cbs)
+callbacks[fids['FEAT_SHIPS']].update(general_vehicle_cbs)
 
 # Aircraft
-callbacks[0x03] = {
+callbacks[fids['FEAT_AIRCRAFT']] = {
     'passenger_capacity'           : [ {'type': 'cb', 'num': 0x15, 'flag_bit': 3},
                                        {'type': 'cb', 'num': 0x36, 'var10': 0x0F, 'purchase': 'purchase_passenger_capacity'}],
     'purchase_passenger_capacity'  : {'type': 'cb', 'num': 0x36, 'var10': 0x0F, 'purchase': 2},
@@ -131,15 +132,15 @@ callbacks[0x03] = {
     'purchase_range'               : {'type': 'cb', 'num': 0x36, 'var10': 0x1F, 'purchase': 2},
     'rotor'                        : {'type': 'override'},
 }
-callbacks[0x03].update(general_vehicle_cbs)
+callbacks[fids['FEAT_AIRCRAFT']].update(general_vehicle_cbs)
 
 # Stations (0x04) are not yet fully implemented
-callbacks[0x04] = {
+callbacks[fids['FEAT_STATIONS']] = {
     'default' : {'type': 'cargo', 'num': None},
 }
 
 # Canals
-callbacks[0x05] = {
+callbacks[fids['FEAT_CANALS']] = {
     'sprite_offset' : {'type': 'cb', 'num': 0x147, 'flag_bit': 0},
     'default'       : {'type': 'cargo', 'num': None},
 }
@@ -147,7 +148,7 @@ callbacks[0x05] = {
 # Bridges (0x06) have no action3
 
 # Houses
-callbacks[0x07] = {
+callbacks[fids['FEAT_HOUSES']] = {
     'random_trigger'         : {'type': 'cb', 'num':  0x01},
     'construction_check'     : {'type': 'cb', 'num':  0x17, 'flag_bit':  0, 'tiles': 'n'},
     'anim_next_frame'        : {'type': 'cb', 'num':  0x1A, 'flag_bit':  1},
@@ -174,7 +175,7 @@ callbacks[0x07] = {
 # General variables (0x08) have no action3
 
 # Industry tiles
-callbacks[0x09] = {
+callbacks[fids['FEAT_INDUSTRYTILES']] = {
     'random_trigger'      : {'type': 'cb', 'num': 0x01},
     'anim_control'        : {'type': 'cb', 'num': 0x25},
     'anim_next_frame'     : {'type': 'cb', 'num': 0x26, 'flag_bit': 0},
@@ -188,7 +189,7 @@ callbacks[0x09] = {
 }
 
 # Industries
-callbacks[0x0A] = {
+callbacks[fids['FEAT_INDUSTRIES']] = {
     'construction_probability' : {'type': 'cb', 'num': 0x22,  'flag_bit': 0},
     'produce_cargo_arrival'    : {'type': 'cb', 'num': 0x00,  'flag_bit': 1, 'var18': 0},
     'produce_256_ticks'        : {'type': 'cb', 'num': 0x00,  'flag_bit': 2, 'var18': 1},
@@ -219,7 +220,7 @@ def cargo_profit_value(value):
     value = expression.BinOp(nmlop.MUL, value, expression.ConstantNumeric(329), value.pos)
     return expression.BinOp(nmlop.DIV, value, expression.ConstantNumeric(256), value.pos)
 
-callbacks[0x0B] = {
+callbacks[fids['FEAT_CARGOS']] = {
     'profit'         : {'type': 'cb', 'num':  0x39, 'flag_bit': 0, 'value_function': cargo_profit_value},
     'station_rating' : {'type': 'cb', 'num': 0x145, 'flag_bit': 1},
     'default'        : {'type': 'cargo', 'num': None},
@@ -228,7 +229,7 @@ callbacks[0x0B] = {
 # Sound effects (0x0C) have no item-specific action3
 
 # Airports
-callbacks[0x0D] = {
+callbacks[fids['FEAT_AIRPORTS']] = {
     'additional_text' : {'type': 'cb', 'num': 0x155},
     'layout_name'     : {'type': 'cb', 'num': 0x156},
     'default'         : {'type': 'cargo', 'num': None},
@@ -237,7 +238,7 @@ callbacks[0x0D] = {
 # New signals (0x0E) have no item-specific action3
 
 # Objects
-callbacks[0x0F] = {
+callbacks[fids['FEAT_OBJECTS']] = {
     'tile_check'      : {'type': 'cb', 'num': 0x157, 'flag_bit': 0, 'purchase': 2},
     'anim_next_frame' : {'type': 'cb', 'num': 0x158, 'flag_bit': 1},
     'anim_control'    : {'type': 'cb', 'num': 0x159},
@@ -250,7 +251,7 @@ callbacks[0x0F] = {
 }
 
 # Railtypes
-callbacks[0x10] = {
+callbacks[fids['FEAT_RAILTYPES']] = {
     # No default here, it makes no sense
     'gui'             : {'type': 'cargo', 'num': 0x00},
     'track_overlay'   : {'type': 'cargo', 'num': 0x01},
@@ -268,10 +269,12 @@ callbacks[0x10] = {
 }
 
 # Airport tiles
-callbacks[0x11] = {
+callbacks[fids['FEAT_AIRPORTTILES']] = {
     'foundations'     : {'type': 'cb', 'num': 0x150, 'flag_bit': 5},
     'anim_control'    : {'type': 'cb', 'num': 0x152},
     'anim_next_frame' : {'type': 'cb', 'num': 0x153, 'flag_bit': 0},
     'anim_speed'      : {'type': 'cb', 'num': 0x154, 'flag_bit': 1},
     'default'         : {'type': 'cargo', 'num': None},
 }
+
+# Generic parent has no action3

--- a/nml/ast/general.py
+++ b/nml/ast/general.py
@@ -35,6 +35,7 @@ feature_ids = {
     'FEAT_OBJECTS': 0x0F,
     'FEAT_RAILTYPES': 0x10,
     'FEAT_AIRPORTTILES': 0x11,
+    'FEAT_GENERIC_PARENT': 0x12, # Always the last item in this list
 }
 
 def feature_name(feature):


### PR DESCRIPTION
So it needs some generic featureID used as parent.

Generally the features probably should be referenced via a symbolic name than their numeric ID in the code or this will fall onto our feet when a new feature is introduced. But that is a separate PR outside the scope of this.

And... I don't understand why this is not an update to the existing PR. Stupid github https://github.com/OpenTTD/nml/pull/26