### PR TITLE
Add compatibility with >=pillow-6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ NML requires the following 3rd party packages to run:
   Minimal version is 3.2. Python 2 is not supported.
 - `python image library`
   For install options see https://pillow.readthedocs.org/installation.html#simple-installation
+  Minimal version is 5.2. Older versions are not supported.
 - `ply`
   Downloadable from http://www.dabeaz.com/ply/
 

--- a/nml/version_info.py
+++ b/nml/version_info.py
@@ -139,11 +139,11 @@ def get_lib_versions():
     #PIL
     try:
         from PIL import Image
-        versions["PIL"] = Image.VERSION
+        versions["PIL"] = Image.PILLOW_VERSION
     except ImportError:
         try:
             import Image
-            versions["PIL"] = Image.VERSION
+            versions["PIL"] = Image.PILLOW_VERSION
         except ImportError:
             versions["PIL"] = "Not found!"
 


### PR DESCRIPTION
Changed VERSION to PILLOW_VERSION,
as it got removed with >=pillow-6.0.0.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>