### PR TITLE
Fix ottd_display_speed to reflect changes done in OpenTTD

### DIFF
--- a/nml/actions/action0properties.py
+++ b/nml/actions/action0properties.py
@@ -255,7 +255,7 @@ general_veh_props = {
 }
 
 def ottd_display_speed(value, divisor, unit):
-    return int(value.value / divisor) * 10 // 16 * unit.ottd_mul >> unit.ottd_shift
+    return (value.value // divisor * 10 * unit.ottd_mul >> unit.ottd_shift) // 16
 
 class VariableByteListProp(BaseAction0Property):
     """


### PR DESCRIPTION
https://github.com/OpenTTD/nml/commit/736f034b4d4ec9e9548247ad0126f08d1db0af7c fixed rounding errors with nml->nfo conversion, however the [ottd_display_speed](https://github.com/OpenTTD/nml/blob/f146d89c5366ec1bbc8f9351ef40b3a59c115024/nml/actions/action0properties.py#L257) function has not been updated to reflect changes done in https://github.com/OpenTTD/OpenTTD/commit/76344163c7d190894629768549130438c34174aa. Specifically, the display value should be divided only after all other conversions have been done. The updated version of the function fixes the many off-by-one rounding errors currently present with nml coded vehicles.