### PR TITLE
Fix #39: Add compatibility with >=pillow-7.0.0

### DIFF
--- a/nml/version_info.py
+++ b/nml/version_info.py
@@ -139,11 +139,17 @@ def get_lib_versions():
     #PIL
     try:
         from PIL import Image
-        versions["PIL"] = Image.PILLOW_VERSION
+        try:
+            versions["PIL"] = Image.__version__
+        except AttributeError:
+            versions["PIL"] = Image.PILLOW_VERSION
     except ImportError:
         try:
             import Image
-            versions["PIL"] = Image.PILLOW_VERSION
+            try:
+                versions["PIL"] = Image.__version__
+            except AttributeError:
+                versions["PIL"] = Image.PILLOW_VERSION
         except ImportError:
             versions["PIL"] = "Not found!"
 


### PR DESCRIPTION
Changed PILLOW_VERSION to PIL.__version__,
as it got removed with >=pillow-7.0.0.

In order not to break compatibility with older versions,
PILLOW_VERSION will be used as a fallback.

Closes: #39
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>