### PR TITLE
Codechange: use pyinstaller to generate standalone executable (and other mostly windows related changes)

### DIFF
--- a/build-dist.bat
+++ b/build-dist.bat
@@ -1,0 +1,2 @@
+python .\setup.py build_ext --inplace
+pyinstaller .\nmlc.spec

--- a/nmlc.spec
+++ b/nmlc.spec
@@ -1,0 +1,33 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(['nmlc'],
+             pathex=['.'],
+             binaries=[('./nml_lz77.*.pyd', '.')],
+             datas=[],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='nmlc',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=True )

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -19,8 +19,8 @@ $(TEST_FILES):
 	$(_V) mkdir -p output nml_output output2
 	$(_V) $(NMLC) $(NML_FLAGS) --nfo output/$@.nfo --grf output/$@.grf $@.nml --nml nml_output/$@.nml && \
 $(NMLC) $(NML_FLAGS) -n --nfo output2/$@.nfo --grf output2/$@.grf nml_output/$@.nml
-	$(_V) diff -u expected/$@.nfo output/$@.nfo && diff -u expected/$@.grf output/$@.grf && \
-diff -u expected/$@.nfo output2/$@.nfo && diff -u expected/$@.grf output2/$@.grf
+	$(_V) diff -u --strip-trailing-cr expected/$@.nfo output/$@.nfo && diff -u expected/$@.grf output/$@.grf && \
+diff -u --strip-trailing-cr expected/$@.nfo output2/$@.nfo && diff -u expected/$@.grf output2/$@.grf
 
 clean:
 	$(_V) rm -rf output nml_output output2 parsetab.py

--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,8 @@ setup(
     },
     ext_modules=[Extension("nml_lz77", ["nml/_lz77.c"], optional=True)],
     python_requires='>=3.5',
+    install_requires=[
+        "Pillow>=5.2",
+        "ply",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,9 @@
 
 import os
 
-from setuptools import Extension, find_packages
-# Use cx_Freeze on Windows only, to generate an actual executable
-if os.name == 'nt':
-    from cx_Freeze import setup, Executable
-else:
-    from setuptools import setup
-
+from setuptools import setup, Extension, find_packages
 from nml import version_info
 NML_VERSION = version_info.get_and_write_version()
-
-if os.name == 'nt':
-    EXE_PARAM = {'executables': [Executable('nmlc')]}
-else:
-    EXE_PARAM = {'scripts': ['nmlc']}
 
 setup(
     name='nml',
@@ -41,7 +30,7 @@ setup(
     url='https://github.com/OpenTTD/nml',
     author='NML Development Team',
     author_email='nml-team@openttdcoop.org',
-    **EXE_PARAM,
+    scripts=['nmlc'],
     ext_modules=[Extension("nml_lz77", ["nml/_lz77.c"], optional=True)],
     python_requires='>=3.5',
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ setup(
     url='https://github.com/OpenTTD/nml',
     author='NML Development Team',
     author_email='nml-team@openttdcoop.org',
-    scripts=['nmlc'],
+    entry_points={
+        'console_scripts': ['nmlc = nml.main:run']
+    },
     ext_modules=[Extension("nml_lz77", ["nml/_lz77.c"], optional=True)],
     python_requires='>=3.5',
 )


### PR DESCRIPTION
cx_Freeze was not working correctly, nml_lz77 lib was built and included but not used.
pyinstaller includes and uses the lib, as long as it's next to `nmlc`, this is enforced in `nmlc.spec`.
`python ./setup.py install` was not really usable on windows, as it copied `nmlc` directly, now setuptools will generate a wrapper executable, as it did before 78cd84c.
The batch file just builds the lib at the right place then creates the standalone exe in `dist`.