### PR TITLE
Simplify pillow imports and version detection

### DIFF
--- a/nml/actions/real_sprite.py
+++ b/nml/actions/real_sprite.py
@@ -16,10 +16,7 @@ with NML; if not, write to the Free Software Foundation, Inc.,
 from nml import generic, expression
 from nml.actions import base_action
 from nml.ast import assignment
-try:
-    from PIL import Image
-except ImportError:
-    import Image
+from PIL import Image
 
 FLAG_NOCROP  = 0x0040
 FLAG_NOALPHA = 0x0100

--- a/nml/main.py
+++ b/nml/main.py
@@ -21,10 +21,7 @@ from nml.ast import grf, alt_sprites
 try:
     from PIL import Image
 except ImportError:
-    try:
-        import Image
-    except ImportError:
-        pass
+    pass
 
 developmode = False # Give 'nice' error message instead of a stack dump.
 

--- a/nml/spriteencoder.py
+++ b/nml/spriteencoder.py
@@ -20,10 +20,7 @@ from nml.actions import real_sprite
 try:
     from PIL import Image
 except ImportError:
-    try:
-        import Image
-    except ImportError:
-        pass
+    pass
 
 # Some constants for the 'info' byte
 INFO_RGB    = 1

--- a/nml/version_info.py
+++ b/nml/version_info.py
@@ -138,20 +138,10 @@ def get_lib_versions():
     versions = {}
     #PIL
     try:
-        from PIL import Image
-        try:
-            versions["PIL"] = Image.__version__
-        except AttributeError:
-            versions["PIL"] = Image.PILLOW_VERSION
+        import PIL
+        versions["PIL"] = PIL.__version__
     except ImportError:
-        try:
-            import Image
-            try:
-                versions["PIL"] = Image.__version__
-            except AttributeError:
-                versions["PIL"] = Image.PILLOW_VERSION
-        except ImportError:
-            versions["PIL"] = "Not found!"
+        versions["PIL"] = "Not found!"
 
     #PLY
     try:


### PR DESCRIPTION
This simplifies the importing and version detection for Pillow by using the imports recommended by Pillow exclusively without fallbacks: `PIL.Image` (supported since before Pillow 1.0) and `PIL.__version__` (supported since Pillow 3.4).

Changes to the version detection were made in #29 and #54 before, but additional discussion in #54 suggests that the changes are not perfectly aligned with Pillow recommendations yet.



As expectd, the version detection seems to work fine for all versions down to Pillow 3.4.0:
```
(venv)matthijs@grubby:~/docs/src/upstream/nml$ pip freeze|grep Pillow
Pillow==6.2.1
(venv)matthijs@grubby:~/docs/src/upstream/nml$ nmlc --version | grep PIL
PIL: 6.2.1


(venv)matthijs@grubby:~/docs/src/upstream/nml$ pip freeze|grep Pillow
Pillow==5.2.0
(venv)matthijs@grubby:~/docs/src/upstream/nml$ nmlc --version | grep PIL
PIL: 5.2.0

(venv)matthijs@grubby:~/docs/src/upstream/nml$ pip freeze|grep Pillow
Pillow==5.0.0
(venv)matthijs@grubby:~/docs/src/upstream/nml$ nmlc --version | grep PIL
PIL: 5.0.0

(venv)matthijs@grubby:~/docs/src/upstream/nml$ pip freeze|grep Pillow
Pillow==3.4.0
(venv)matthijs@grubby:~/docs/src/upstream/nml$ nmlc --version | grep PIL
PIL: 3.4.0
```
As expected, below 3.4.0, `PIL.__version__` is not available:
```
(venv)matthijs@grubby:~/docs/src/upstream/nml$ pip freeze|grep Pillow
Pillow==3.3.3
(venv)matthijs@grubby:~/docs/src/upstream/nml$ nmlc --version | grep PIL
nmlc ERROR: nmlc: An internal error has occurred:
nmlc-version: 2019-11-09-gabb7a3a7M
Error:    (AttributeError) "module 'PIL' has no attribute '__version__'".
Command:  ['/home/matthijs/docs/src/upstream/nml/venv/bin/nmlc', '--version']
Location: File "/home/matthijs/docs/src/upstream/nml/nml/version_info.py", line 140, in get_lib_versions
```

I've tested the regular imports (i.e. not the version detection, but normal operation) against Pillow 3.4.0 and 6.2.1 using `make -C regression` and by compiling OpenGFX 0.5.5.