### PR TITLE
Fix: enable VT100 sequences on windows

### DIFF
--- a/nml/generic.py
+++ b/nml/generic.py
@@ -377,7 +377,7 @@ def print_warning(msg, pos = None):
     msg = " nmlc warning: " + msg
 
     if sys.stderr.isatty():
-        msg = "\033[33m" + msg + "\033[0m"
+        msg = "\033[93m" + msg + "\033[0m"
 
     hide_progress()
     print(msg, file=sys.stderr)

--- a/nml/generic.py
+++ b/nml/generic.py
@@ -388,7 +388,13 @@ def print_error(msg):
     Output an error message to the user.
     """
     clear_progress()
-    print("nmlc ERROR: " + msg, file=sys.stderr)
+
+    msg = " nmlc ERROR: " + msg
+
+    if sys.stderr.isatty():
+        msg = "\033[91m" + msg + "\033[0m"
+
+    print(msg, file=sys.stderr)
 
 def print_dbg(indent, *args):
     """


### PR DESCRIPTION
`[K` on my screen were annoying so instead of removing them I enabled support for them. As VT100 sequences are now enabled, color codes can be used too so I re-enabled the warning color and I changed it to bright yellow because it seems normal yellow is the default powershell foreground (even if visually it's some pale white). And I added color to error messages (bright red, because red is hard to read on default blue powershell background)

Commits should probably be squashed, but that can happen when merging.