### PR TITLE
Minor changes in regression Makefile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ nml/__version__.py
 nml/generated/parsetab.py
 nml/generated/lextab.py
 **/.nmlcache
+nml.egg-info/*
+nml_lz77*
+regression/*output*/*

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -17,10 +17,14 @@ all: $(TEST_FILES)
 $(TEST_FILES):
 	$(_V) echo "Running test $@"
 	$(_V) mkdir -p output nml_output output2
-	$(_V) $(NMLC) $(NML_FLAGS) --nfo output/$@.nfo --grf output/$@.grf $@.nml --nml nml_output/$@.nml && \
-$(NMLC) $(NML_FLAGS) -n --nfo output2/$@.nfo --grf output2/$@.grf nml_output/$@.nml
-	$(_V) diff -u --strip-trailing-cr expected/$@.nfo output/$@.nfo && diff -u expected/$@.grf output/$@.grf && \
-diff -u --strip-trailing-cr expected/$@.nfo output2/$@.nfo && diff -u expected/$@.grf output2/$@.grf
+# First pass : check compilation of source nml and generation of optimised nml
+	$(_V) $(NMLC) $(NML_FLAGS) --nfo output/$@.nfo --grf output/$@.grf $@.nml --nml nml_output/$@.nml
+	$(_V) diff -u --strip-trailing-cr expected/$@.nfo output/$@.nfo
+	$(_V) diff -u expected/$@.grf output/$@.grf
+# Second pass : check compilation of optimised nml
+	$(_V) $(NMLC) $(NML_FLAGS) -n --nfo output2/$@.nfo --grf output2/$@.grf nml_output/$@.nml
+	$(_V) diff -u --strip-trailing-cr expected/$@.nfo output2/$@.nfo
+	$(_V) diff -u expected/$@.grf output2/$@.grf
 
 clean:
-	$(_V) rm -rf output nml_output output2 parsetab.py
+	$(_V) rm -rf output nml_output output2


### PR DESCRIPTION
I made the Makefile easier to read by spliting the multiline commands and adding comments.
I also added to .gitignore all files generated by regression, the compiled lz77 lib and the files generated by `pip install -e .`