### PR TITLE
Fix: close image files after use during palette check

### DIFF
--- a/nml/main.py
+++ b/nml/main.py
@@ -335,6 +335,7 @@ def nml(inputfile, input_filename, output_debug, outputfiles, start_sprite_num, 
         if im.mode != "P":
             continue
         pal = palette.validate_palette(im, f)
+        im.close()
 
         if forced_palette != "ANY" and pal != forced_palette and not (forced_palette == "DEFAULT" and pal == "LEGACY"):
             raise generic.ImageError("Image has '{}' palette, but you forced the '{}' palette".format(pal, used_palette), f)


### PR DESCRIPTION
With pypy, nmlc trivially trips file handle limits on macOS during palette checks, resulting in: "[Errno 24] Too many open files".

This is a common enough problem in python, which can be resolved by either

- end user setting `ulimit -n 4096` on a per shell basis
- closing PIL Image files with `Image.close()`, where `Image.open()` has been used 

_This PR closes images opened for palette checks, which is a trivial case.  Errno 24 no longer triggers for me. Tests pass._

Errno 24 does not trigger for me with any cPython 3.x, but pypy cuts run times by up to 50% in my testing compared to cPython 3.8, so we do want to be compatible with pypy.

There are a couple of other uses of Image.open() but they looked less trivial, and they're not tripping Errno 24 for me.

For the record, `Image.load()` self-closes so wouldn't have the same issue, but `Image.open()` is often the wanted command, especially for reading metadata.
