### PR TITLE
Add: nmlc option to force regeneration of parser tables

### DIFF
--- a/nml/main.py
+++ b/nml/main.py
@@ -40,7 +40,8 @@ def parse_cli(argv):
     opt_parser = optparse.OptionParser(usage=usage, version=version_info.get_cli_version())
     opt_parser.set_defaults(debug=False, crop=False, compress=True, outputs=[], start_sprite_num=0,
                             custom_tags="custom_tags.txt", lang_dir="lang", default_lang="english.lng", cache_dir=".nmlcache",
-                            forced_palette="ANY", quiet=False, md5_filename=None, keep_orphaned=True, verbosity=generic.verbosity_level, rebuild_parser=False)
+                            forced_palette="ANY", quiet=False, md5_filename=None, keep_orphaned=True, verbosity=generic.verbosity_level,
+                            rebuild_parser=False, debug_parser=False)
     opt_parser.add_option("-d", "--debug", action="store_true", dest="debug", help="write the AST to stdout")
     opt_parser.add_option("-s", "--stack", action="store_true", dest="stack", help="Dump stack when an error occurs")
     opt_parser.add_option("--grf", dest="grf_filename", metavar="<file>", help="write the resulting grf to <file>")
@@ -71,6 +72,7 @@ def parse_cli(argv):
     opt_parser.add_option("--clear-orphaned", action="store_false", dest="keep_orphaned", help="Remove unused/orphaned items from cache files.")
     opt_parser.add_option("--verbosity", type="int", dest="verbosity", metavar="<level>", help="Set the verbosity level for informational output. [default: %default, max: {}]".format(generic.VERBOSITY_MAX))
     opt_parser.add_option("-R", "--rebuild-parser", action="store_true", dest="rebuild_parser", help="Force regeneration of parser tables.")
+    opt_parser.add_option("-D", "--debug-parser", action="store_true", dest="debug_parser", help="Enable debug mode for parser.")
 
     opts, args = opt_parser.parse_args(argv)
 
@@ -165,7 +167,7 @@ def main(argv):
             generic.print_error("Unknown output format {}".format(outext))
             sys.exit(2)
 
-    ret = nml(input, input_filename, opts.debug, outputs, opts.start_sprite_num, opts.compress, opts.crop, not opts.no_cache, opts.forced_palette, opts.md5_filename, opts.rebuild_parser)
+    ret = nml(input, input_filename, opts.debug, outputs, opts.start_sprite_num, opts.compress, opts.crop, not opts.no_cache, opts.forced_palette, opts.md5_filename, opts.rebuild_parser, opts.debug_parser)
 
     input.close()
     sys.exit(ret)
@@ -173,7 +175,7 @@ def main(argv):
 def filename_output_from_input(name, ext):
     return os.path.splitext(name)[0] + ext
 
-def nml(inputfile, input_filename, output_debug, outputfiles, start_sprite_num, compress_grf, crop_sprites, enable_cache, forced_palette, md5_filename, rebuild_parser):
+def nml(inputfile, input_filename, output_debug, outputfiles, start_sprite_num, compress_grf, crop_sprites, enable_cache, forced_palette, md5_filename, rebuild_parser, debug_parser):
     """
     Compile an NML file.
 
@@ -221,7 +223,7 @@ def nml(inputfile, input_filename, output_debug, outputfiles, start_sprite_num, 
 
     generic.print_progress("Init parser ...")
 
-    nml_parser = parser.NMLParser(rebuild_parser)
+    nml_parser = parser.NMLParser(rebuild_parser, debug_parser)
     if input_filename is None:
         input_filename = 'input'
 

--- a/nml/main.py
+++ b/nml/main.py
@@ -40,7 +40,7 @@ def parse_cli(argv):
     opt_parser = optparse.OptionParser(usage=usage, version=version_info.get_cli_version())
     opt_parser.set_defaults(debug=False, crop=False, compress=True, outputs=[], start_sprite_num=0,
                             custom_tags="custom_tags.txt", lang_dir="lang", default_lang="english.lng", cache_dir=".nmlcache",
-                            forced_palette="ANY", quiet=False, md5_filename=None, keep_orphaned=True, verbosity=generic.verbosity_level)
+                            forced_palette="ANY", quiet=False, md5_filename=None, keep_orphaned=True, verbosity=generic.verbosity_level, rebuild_parser=False)
     opt_parser.add_option("-d", "--debug", action="store_true", dest="debug", help="write the AST to stdout")
     opt_parser.add_option("-s", "--stack", action="store_true", dest="stack", help="Dump stack when an error occurs")
     opt_parser.add_option("--grf", dest="grf_filename", metavar="<file>", help="write the resulting grf to <file>")
@@ -70,6 +70,7 @@ def parse_cli(argv):
     opt_parser.add_option("--cache-dir", dest="cache_dir", metavar="<dir>", help="Cache files are stored in directory <dir> [default: %default]")
     opt_parser.add_option("--clear-orphaned", action="store_false", dest="keep_orphaned", help="Remove unused/orphaned items from cache files.")
     opt_parser.add_option("--verbosity", type="int", dest="verbosity", metavar="<level>", help="Set the verbosity level for informational output. [default: %default, max: {}]".format(generic.VERBOSITY_MAX))
+    opt_parser.add_option("-R", "--rebuild-parser", action="store_true", dest="rebuild_parser", help="Force regeneration of parser tables.")
 
     opts, args = opt_parser.parse_args(argv)
 
@@ -164,7 +165,7 @@ def main(argv):
             generic.print_error("Unknown output format {}".format(outext))
             sys.exit(2)
 
-    ret = nml(input, input_filename, opts.debug, outputs, opts.start_sprite_num, opts.compress, opts.crop, not opts.no_cache, opts.forced_palette, opts.md5_filename)
+    ret = nml(input, input_filename, opts.debug, outputs, opts.start_sprite_num, opts.compress, opts.crop, not opts.no_cache, opts.forced_palette, opts.md5_filename, opts.rebuild_parser)
 
     input.close()
     sys.exit(ret)
@@ -172,7 +173,7 @@ def main(argv):
 def filename_output_from_input(name, ext):
     return os.path.splitext(name)[0] + ext
 
-def nml(inputfile, input_filename, output_debug, outputfiles, start_sprite_num, compress_grf, crop_sprites, enable_cache, forced_palette, md5_filename):
+def nml(inputfile, input_filename, output_debug, outputfiles, start_sprite_num, compress_grf, crop_sprites, enable_cache, forced_palette, md5_filename, rebuild_parser):
     """
     Compile an NML file.
 
@@ -220,7 +221,7 @@ def nml(inputfile, input_filename, output_debug, outputfiles, start_sprite_num, 
 
     generic.print_progress("Init parser ...")
 
-    nml_parser = parser.NMLParser()
+    nml_parser = parser.NMLParser(rebuild_parser)
     if input_filename is None:
         input_filename = 'input'
 

--- a/nml/parser.py
+++ b/nml/parser.py
@@ -29,13 +29,19 @@ class NMLParser:
     @ivar parser: PLY parser.
     @type parser: L{ply.yacc}
     """
-    def __init__(self, rebuild = False):
+    def __init__(self, rebuild = False, debug = False):
+        if debug:
+            try:
+                import os
+                os.remove(os.path.normpath(os.path.join(os.path.dirname(__file__), "generated", "parsetab.py")))
+            except FileNotFoundError:
+                pass
         self.lexer = tokens.NMLLexer()
-        self.lexer.build(rebuild)
+        self.lexer.build(rebuild or debug)
         self.tokens = self.lexer.tokens
         self.parser = yacc.yacc(module=self,
-                                debug=False, optimize=not rebuild,
-                                write_tables=True,
+                                debug=debug, optimize=not (rebuild or debug),
+                                write_tables=not debug,
                                 tabmodule='nml.generated.parsetab')
 
     def parse(self, text, input_filename):

--- a/nml/parser.py
+++ b/nml/parser.py
@@ -29,12 +29,12 @@ class NMLParser:
     @ivar parser: PLY parser.
     @type parser: L{ply.yacc}
     """
-    def __init__(self):
+    def __init__(self, rebuild = False):
         self.lexer = tokens.NMLLexer()
-        self.lexer.build()
+        self.lexer.build(rebuild)
         self.tokens = self.lexer.tokens
         self.parser = yacc.yacc(module=self,
-                                debug=False, optimize=True,
+                                debug=False, optimize=not rebuild,
                                 write_tables=True,
                                 tabmodule='nml.generated.parsetab')
 

--- a/nml/tokens.py
+++ b/nml/tokens.py
@@ -243,10 +243,16 @@ class NMLLexer:
 
 
 
-    def build(self):
+    def build(self, rebuild = False):
         """
         Initial construction of the scanner.
         """
+        if rebuild:
+            try:
+                import os
+                os.remove(os.path.normpath(os.path.join(os.path.dirname(__file__), "generated", "lextab.py")))
+            except FileNotFoundError:
+                pass
         self.lexer = lex.lex(module=self, optimize=1, lextab='nml.generated.lextab')
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class NMLBuildPy(build_py):
     def run(self):
         # Create a parser so that nml/generated/{parse,lex}tab.py are generated.
         from nml import parser
-        parser.NMLParser()
+        parser.NMLParser(rebuild=True)
         # Then continue with the normal setuptools build.
         super().run()
 


### PR DESCRIPTION
Since merge of #63, parser tables are not regenerated when parser and lexer are modified. This new option works around it without disabling optimisations.