### PR TITLE
Fix: don't try to debug_print not set optional GRF param number

### DIFF
--- a/nml/ast/grf.py
+++ b/nml/ast/grf.py
@@ -296,7 +296,8 @@ class ParameterDescription:
         return ret
 
     def debug_print(self, indentation):
-        self.num.debug_print(indentation)
+        if self.num is not None:
+            self.num.debug_print(indentation)
         for setting in self.setting_list:
             setting.debug_print(indentation + 2)
 


### PR DESCRIPTION
Without this fix, `nmlc -d .\example_train.nml` crashes