### PR TITLE
Add: optimise switches

### DIFF
--- a/nml/ast/switch.py
+++ b/nml/ast/switch.py
@@ -128,9 +128,14 @@ class SwitchBody:
                 self.ranges.remove(r)
             else:
                 r.reduce_expressions(var_feature, extra_dicts)
-        if self.default is not None and self.default.value is not None:
-            self.default.value = action2var.reduce_varaction2_expr(self.default.value, var_feature, extra_dicts)
-
+        if self.default is not None:
+            if self.default.value is not None:
+                self.default.value = action2var.reduce_varaction2_expr(self.default.value, var_feature, extra_dicts)
+            if len(self.ranges) != 0:
+                if any(self.default.value != r.result.value for r in self.ranges):
+                    return
+                generic.print_warning("Switch-Block ranges are the same as default, optimising.", self.default.pos)
+                self.ranges = []
 
     def debug_print(self, indentation):
         for r in self.ranges:

--- a/nml/expression/array.py
+++ b/nml/expression/array.py
@@ -35,3 +35,6 @@ class Array(Expression):
     def collect_references(self):
         from itertools import chain
         return list(chain.from_iterable(v.collect_references() for v in self.values))
+
+    def is_read_only(self):
+        return all(v.is_read_only() for v in self.values)

--- a/nml/expression/base_expression.py
+++ b/nml/expression/base_expression.py
@@ -110,6 +110,14 @@ class Expression:
         """
         return []
 
+    def is_read_only(self):
+        """
+        Check if this expression store values.
+
+        @return: True if the expression doesn't store values.
+        """
+        return True
+
     def is_boolean(self):
         """
         Check if this expression is limited to 0 or 1 as value.

--- a/nml/expression/bin_not.py
+++ b/nml/expression/bin_not.py
@@ -44,6 +44,9 @@ class BinNot(Expression):
     def collect_references(self):
         return self.expr.collect_references()
 
+    def is_read_only(self):
+        return self.expr.is_read_only()
+
     def __str__(self):
         return "~" + str(self.expr)
 
@@ -81,6 +84,9 @@ class Not(Expression):
 
     def collect_references(self):
         return self.expr.collect_references()
+
+    def is_read_only(self):
+        return self.expr.is_read_only()
 
     def is_boolean(self):
         return True

--- a/nml/expression/binop.py
+++ b/nml/expression/binop.py
@@ -184,6 +184,9 @@ class BinOp(Expression):
     def collect_references(self):
         return self.expr1.collect_references() + self.expr2.collect_references()
 
+    def is_read_only(self):
+        return self.expr1.is_read_only() and self.expr2.is_read_only()
+
     def is_boolean(self):
         if self.op in (nmlop.AND, nmlop.OR, nmlop.XOR):
             return self.expr1.is_boolean() and self.expr2.is_boolean()

--- a/nml/expression/bitmask.py
+++ b/nml/expression/bitmask.py
@@ -43,5 +43,8 @@ class BitMask(Expression):
         from itertools import chain
         return list(chain.from_iterable(v.collect_references() for v in self.values))
 
+    def is_read_only(self):
+        return all(v.is_read_only() for v in self.values)
+
     def __str__(self):
         return "bitmask(" + ", ".join(str(e) for e in self.values) + ")"

--- a/nml/expression/boolean.py
+++ b/nml/expression/boolean.py
@@ -47,6 +47,9 @@ class Boolean(Expression):
     def collect_references(self):
         return self.expr.collect_references()
 
+    def is_read_only(self):
+        return self.expr.is_read_only()
+
     def is_boolean(self):
         return True
 

--- a/nml/expression/spritegroup_ref.py
+++ b/nml/expression/spritegroup_ref.py
@@ -82,6 +82,9 @@ class SpriteGroupRef(Expression):
                     len(spritegroup.body.ranges) == 0:
                 generic.print_warning("Block '{}' returns a constant, optimising.".format(spritegroup.name.value), self.pos)
                 return spritegroup.body.default.value
+            elif isinstance(spritegroup, switch.RandomSwitch) and len(spritegroup.choices) == 1:
+                generic.print_warning("Block '{}' returns a constant, optimising.".format(spritegroup.name.value), self.pos)
+                return spritegroup.choices[0].result.value
         return self
 
     def supported_by_action2(self, raise_error):

--- a/nml/expression/storage_op.py
+++ b/nml/expression/storage_op.py
@@ -124,3 +124,7 @@ class StorageOp(Expression):
 
     def collect_references(self):
         return self.register.collect_references() + (self.value.collect_references() if self.value is not None else [])
+
+    def is_read_only(self):
+        assert(self.info['store'] == (self.value is not None))
+        return (not self.info['store']) and self.register.is_read_only()

--- a/nml/expression/ternaryop.py
+++ b/nml/expression/ternaryop.py
@@ -54,6 +54,9 @@ class TernaryOp(Expression):
     def collect_references(self):
         return self.guard.collect_references() + self.expr1.collect_references() + self.expr2.collect_references()
 
+    def is_read_only(self):
+        return self.expr1.is_read_only() and self.expr2.is_read_only()
+
     def is_boolean(self):
         return self.expr1.is_boolean() and self.expr2.is_boolean()
 


### PR DESCRIPTION
I had the idea after seeing [this pastebin](https://pastebin.com/raw/ECg7qg5L) from Andy.

With this PR the following code
```
switch (FEAT_TRAINS, SELF, open_car_pony_gen_6C_switch_loading_speed_by_cargo_0, cargo_classes & bitmask(CC_PASSENGERS, CC_MAIL, CC_ARMOURED)) {
	bitmask(CC_PASSENGERS): return 6;
	bitmask(CC_MAIL): return 6;
	bitmask(CC_ARMOURED): return 6;
	return 6;
}
switch (FEAT_TRAINS, SELF, open_car_pony_gen_6C_switch_loading_speed_by_cargo_1, cargo_classes & bitmask(CC_PASSENGERS, CC_MAIL, CC_ARMOURED)) {
	bitmask(CC_PASSENGERS): return 8;
	bitmask(CC_MAIL): return 8;
	bitmask(CC_ARMOURED): return 8;
	return 8;
}
switch (FEAT_TRAINS, SELF, open_car_pony_gen_6C_switch_loading_speed_by_cargo_2, cargo_classes & bitmask(CC_PASSENGERS, CC_MAIL, CC_ARMOURED)) {
	bitmask(CC_PASSENGERS): return 11;
	bitmask(CC_MAIL): return 11;
	bitmask(CC_ARMOURED): return 11;
	return 11;
}
switch (FEAT_TRAINS, SELF, open_car_pony_gen_6C_switch_loading_speed, param[0]) {
    0: open_car_pony_gen_6C_switch_loading_speed_by_cargo_0;
    1: open_car_pony_gen_6C_switch_loading_speed_by_cargo_1;
    2: open_car_pony_gen_6C_switch_loading_speed_by_cargo_2;
}
```
will be replaced at compile time with
```
switch (FEAT_TRAINS, SELF, open_car_pony_gen_6C_switch_loading_speed, param[0]) {
    0: return 6;
    1: return 8;
    2: return 11;
}
```
Each replacement generates a warning and the replacement is done only if the switch expression doesn't have side effects (no STORE_TEMP() nor STORE_PERM()) and if there's a default return.