### PR TITLE
Change: add TTDPatchFlag 0x80 

### DIFF
--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -1189,6 +1189,7 @@ config_flags = {
     'newcargos'               : 0x6B,
     'dynamic_engines'         : 0x78,
     'variable_runningcosts'   : 0x7E,
+    '256_persistent_registers': 0x80,
 }
 
 def unified_maglev_read(info, pos):


### PR DESCRIPTION
(256 persistent registers, available since OpenTTD 1.9.0)

I have no idea if this is required, but it's listed in https://wiki.openttd.org/NewGRF_Specification_Status#OpenTTD_1.9 and also Eddi advises that compilers should completely implement the spec.