### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -52,7 +52,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: ${{ startsWith(matrix.os, 'windows') && 'x86' || 'x64' }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '*'
+
+jobs:
+  release:
+    name: Python 3.x on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-2016]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v1
+      if: startsWith(matrix.os, 'ubuntu')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - uses: actions/cache@v1
+      if: startsWith(matrix.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - uses: actions/cache@v1
+      if: startsWith(matrix.os, 'windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        pip install -e .
+
+    - name: Build manylinux Python wheels
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2014_x86_64
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
+        build-requirements: '-e .'  # pip args
+
+    - name: Publish manylinux Python wheels
+      if: startsWith(matrix.os, 'ubuntu')
+      env:
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        twine upload --username __token__ wheelhouse/*-manylinux*.whl
+
+    - name: Build and publish wheel
+      if: "! startsWith(matrix.os, 'ubuntu')"
+      env:
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload --username __token__ dist/*.whl
+
+    # Only do this on Windows to prevent file conflicts
+    - name: Build and publish source distribution
+      if: startsWith(matrix.os, 'windows')
+      env:
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        twine upload --username __token__ dist/*.tar.gz
+
+    - name: Build standalone executable
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        pip install --upgrade pyinstaller
+        pyinstaller nmlc.spec
+        $version = python setup.py --version
+        echo "::set-output name=version::$version"
+      id: nml_version
+
+    - name: Archive executable
+      if: startsWith(matrix.os, 'windows')
+      uses: actions/upload-artifact@v1
+      with:
+        name: nml-${{ steps.nml_version.outputs.version }}-win64
+        path: dist/nmlc.exe

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,60 @@
+name: Testing
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+
+jobs:
+  testing:
+    name: Python 3.x on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-2016]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v1
+      if: startsWith(matrix.os, 'ubuntu')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - uses: actions/cache@v1
+      if: startsWith(matrix.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - uses: actions/cache@v1
+      if: startsWith(matrix.os, 'windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+
+    # Just check we can successfully build it
+    - name: Build standalone executable
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        pip install pyinstaller
+        pyinstaller ./nmlc.spec

--- a/nml/version_info.py
+++ b/nml/version_info.py
@@ -118,9 +118,9 @@ def get_git_version(detailed = False):
 
         # Compose the actual version string
         str_tag = ""
-        if len(tag) > 0:
-            version = tag[0]
-            str_tag = tag[0]
+        if tag:
+            version = tag
+            str_tag = tag
         elif branch == "master":
             version = isodate + "-g" + changeset
         else:


### PR DESCRIPTION
Not finished yet

* [x] Build Python wheels for Windows, MacOS & Linux (manylinux2010)
* [x] Builds standalone (win64) nmlc executable
* [x] Fixes a bug in git version calculation with tags
* [x] Make py38 work ( RalfG/python-wheels-manylinux-build#14 )
* [x] Work out which artefacts want to be distributed with the release (fixes Linux release failure)
* [x] ~See if build artefacts can be attached to the release~ Not worth the bother
* [x] Remove test code
* [x] Add `PYPI_PASSWORD` secrets to repo

Latest release build example: https://github.com/LordAro/nml/actions/runs/83157723