### PR TITLE
Change: Use PyPy's StringBuilder to speed up the use of StringIO.

### DIFF
--- a/nml/output_base.py
+++ b/nml/output_base.py
@@ -16,7 +16,9 @@ with NML; if not, write to the Free Software Foundation, Inc.,
 """
 Abstract base classes that implements common functionality for output classes
 """
-import array, io
+import array
+import io
+from nml.util import StringIO
 
 class OutputBase:
     """
@@ -286,7 +288,7 @@ class TextOutputBase(OutputBase):
         OutputBase.__init__(self, filename)
 
     def open(self):
-        self.file = io.StringIO()
+        self.file = StringIO()
 
 
 class BinaryOutputBase(SpriteOutputBase):

--- a/nml/output_nfo.py
+++ b/nml/output_nfo.py
@@ -14,9 +14,9 @@ with NML; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
 # -*- coding: utf-8 -*-
-import io
 from nml import generic, grfstrings, output_base
 from nml.actions import real_sprite
+from nml.util import StringIO
 
 zoom_levels = {
     0 : 'normal',
@@ -38,7 +38,7 @@ class OutputNFO(output_base.SpriteOutputBase):
         self.sprite_num = start_sprite_num
 
     def open(self):
-        self.file = io.StringIO()
+        self.file = StringIO()
 
     def open_file(self):
         handle = open(self.filename, 'w', encoding='utf-8')

--- a/nml/util.py
+++ b/nml/util.py
@@ -1,0 +1,17 @@
+try:
+    from __pypy__.builders import StringBuilder
+    class StringIO:
+        """
+        Mimic basic StringIO behavior, but then faster.
+        """
+        def __init__(self):
+            self.builder = StringBuilder()
+            self.write = self.builder.append
+        def getvalue(self):
+            return self.builder.build()
+except ImportError:
+    from io import StringIO
+
+__all__ = [
+    "StringIO",
+]


### PR DESCRIPTION
This is an alternative to #76 .

Inspiration was found from https://bitbucket.org/pypy/pypy/pull-requests/132/speed-up-pickledumps-fixes-issue-979/diff , where a similar fix was applied to speed up pickle.dumps for PyPy.

This only affects PyPy, normal CPython versions will still use `io.StringIO`, therefore not incurring any performance loss.