### PR TITLE
Fix #100: follow PEP440 when generating version

### DIFF
--- a/nml/version_info.py
+++ b/nml/version_info.py
@@ -121,13 +121,14 @@ def get_git_version(detailed = False):
         if tag:
             version = tag
             str_tag = tag
-        elif branch == "master":
-            version = isodate + "-g" + changeset
         else:
-            version = isodate + "-" + branch + "-g" + changeset
+            version = "0.5.0.dev" + isodate.replace("-", "") + "+"
+            if branch != "master":
+                version += branch + "."
+            version += "g" + changeset
 
         if modified:
-            version += "M"
+            version += "m"
 
         if detailed:
             version = changeset + ";" + branch + ";" + str_tag + ";" + str(modified) + ";" + isodate + ";" + version


### PR DESCRIPTION
Previous, and invalid, version format was `<year>-<month>-<day>[-<branch>]-g<changeset>[M]`.
I replaced it with `<next nml version>.dev<year><month><day>+[branch.]g<changeset>[m]`.
For releases it will still use `<tag>[m]`, and a modified tag source will be considered as invalid.