### PR TITLE
Codechange: [Actions] Upload standalone executable to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-    - '*'
+  release:
+    types: [published]
 
 jobs:
   release:
@@ -88,12 +87,18 @@ jobs:
         pip install --upgrade pyinstaller
         pyinstaller nmlc.spec
         $version = python setup.py --version
-        echo "::set-output name=version::$version"
-      id: nml_version
+        $archive = echo "nml-$version-win64.zip"
+        Compress-Archive -Path dist/nmlc.exe, LICENSE, README.md, docs/changelog.txt -DestinationPath $archive
+        echo "::set-output name=archive::$archive"
+      id: nml_archive
 
-    - name: Archive executable
+    - name: Publish standalone executable
       if: startsWith(matrix.os, 'windows')
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: nml-${{ steps.nml_version.outputs.version }}-win64
-        path: dist/nmlc.exe
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ steps.nml_archive.outputs.archive }}
+        asset_name: ${{ steps.nml_archive.outputs.archive }}
+        asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ For large releases and/or if there are deprecations or nml syntax changes, provi
 Example: https://github.com/OpenTTD/nml/blob/master/docs/changelog.txt
 4. Publish a new release using the release tool in the GitHub project: https://github.com/OpenTTD/nml/releases/new
 5. GitHub Actions will build the release and publish to PyPI (the Python package index).
-6. GitHub Actions will publish the Windows binary as an artefact.
-Download this, then upload it to the GitHub release.
+6. GitHub Actions will publish the Windows binary to the GitHub release.
 7. (Optional) announce the release in places such as https://www.tt-forums.net/viewforum.php?f=68
 
 


### PR DESCRIPTION
I merged it into my [master](https://github.com/glx22/nml/commits/master) (with a temp commit to disable PyPi stuff. Then I created a [release](https://github.com/glx22/nml/releases/tag/test) to trigger it.

Seems to work as intended. Actions run log is [here](https://github.com/glx22/nml/runs/620714617?check_suite_focus=true).

Hmm I should probably rebase and update the `README` too. And maybe add the changelog in the zip.