### PR TITLE
Fix: Correct limit of available road/tramtypes.

### DIFF
--- a/nml/actions/action0.py
+++ b/nml/actions/action0.py
@@ -204,8 +204,8 @@ used_ids = [
     BlockAllocation(  0,    255, "Object"),
     BlockAllocation(  0,     63, "Railtype"),
     BlockAllocation(  0,    255, "Airport Tile"),
-    BlockAllocation(  0,     15, "Roadtype"),
-    BlockAllocation(  0,     15, "Tramtype"),
+    BlockAllocation(  0,     62, "Roadtype"),
+    BlockAllocation(  0,     62, "Tramtype"),
 ]
 
 def print_stats():


### PR DESCRIPTION
According to the NFO spec, there can be up to 63 each of road/tramtypes.

OpenTTD also requires that the *combined* total of road and tram types be
 no more than 63, and that a label used for a roadtype cannot be used for
 a tramtype or vice versa.

This directly contradicts the NFO specification, and nmlc will not
 check for, nor enforce, these additional limitations.