### PR TITLE
Rewrite release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,37 +5,53 @@ on:
     types: [published]
 
 jobs:
-  release:
-    name: Python 3.x on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-2016]
+  release-ubuntu:
+    name: Ubuntu release
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - uses: actions/cache@v1
-      if: startsWith(matrix.os, 'ubuntu')
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - uses: actions/cache@v1
-      if: startsWith(matrix.os, 'macOS')
+    - name: Set up Python
+      uses: actions/setup-python@v1
       with:
-        path: ~/Library/Caches/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        python-version: '3.x'
+
+    - name: Install twine
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine
+
+    - name: Build manylinux Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2014_x86_64
+      with:
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
+        build-requirements: '-e .'  # pip args
+
+    - name: Publish manylinux Python wheels
+      env:
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        twine upload --username __token__ wheelhouse/*-manylinux*.whl
+
+
+  release-osx:
+    name: MacOS release
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v2
 
     - uses: actions/cache@v1
-      if: startsWith(matrix.os, 'windows')
       with:
-        path: ~\AppData\Local\pip\Cache
+        path: ~/Library/Caches/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
@@ -51,40 +67,52 @@ jobs:
         pip install setuptools wheel twine
         pip install -e .
 
-    - name: Build manylinux Python wheels
-      if: startsWith(matrix.os, 'ubuntu')
-      uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2014_x86_64
-      with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
-        build-requirements: '-e .'  # pip args
-
-    - name: Publish manylinux Python wheels
-      if: startsWith(matrix.os, 'ubuntu')
-      env:
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload --username __token__ wheelhouse/*-manylinux*.whl
-
-    - name: Build and publish wheel
-      if: "! startsWith(matrix.os, 'ubuntu')"
+    # Only publish source package on one OS, to prevent PyPI file conflicts.
+    # Use MacOS rather than Windows to get LF rather than CRLF line endings
+    # (useful for Debian source packages), and MacOS rather than Linux, since
+    # the latter has a different build process.
+    - name: Build and publish wheel and source distribution
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload --username __token__ dist/*.whl
+        twine upload --username __token__ dist/*.whl dist/*.tar.gz
 
-    # Only do this on Windows to prevent file conflicts
-    - name: Build and publish source distribution
-      if: startsWith(matrix.os, 'windows')
+
+  release-windows:
+    name: Windows release
+    runs-on: windows-2016
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v1
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine pyinstaller
+        pip install -e .
+
+    - name: Build and publish wheel
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        twine upload --username __token__ dist/*.tar.gz
+        python setup.py bdist_wheel
+        twine upload --username __token__ dist/*.whl
 
     - name: Build standalone executable
-      if: startsWith(matrix.os, 'windows')
       run: |
-        pip install --upgrade pyinstaller
         pyinstaller nmlc.spec
         $version = python setup.py --version
         $archive = echo "nml-standalone-$version-win64.zip"
@@ -93,7 +121,6 @@ jobs:
       id: nml_archive
 
     - name: Publish standalone executable
-      if: startsWith(matrix.os, 'windows')
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Checkout tags
+      uses: openttd/actions/checkout@v1
+      with:
+        with-tags: true
 
     - uses: actions/cache@v1
       with:
@@ -48,6 +55,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Checkout tags
+      uses: openttd/actions/checkout@v1
+      with:
+        with-tags: true
 
     - uses: actions/cache@v1
       with:
@@ -98,6 +112,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Checkout tags
+      uses: openttd/actions/checkout@v1
+      with:
+        with-tags: true
 
     - uses: actions/cache@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-    - '*'
+  release:
+    types: [published]
 
 jobs:
   release:
@@ -88,12 +87,18 @@ jobs:
         pip install --upgrade pyinstaller
         pyinstaller nmlc.spec
         $version = python setup.py --version
-        echo "::set-output name=version::$version"
-      id: nml_version
+        $archive = echo "nml-standalone-$version-win64.zip"
+        Compress-Archive -Path dist/nmlc.exe, LICENSE, README.md, docs/changelog.txt -DestinationPath $archive
+        echo "::set-output name=archive::$archive"
+      id: nml_archive
 
-    - name: Archive executable
+    - name: Publish standalone executable
       if: startsWith(matrix.os, 'windows')
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: nml-${{ steps.nml_version.outputs.version }}-win64
-        path: dist/nmlc.exe
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ steps.nml_archive.outputs.archive }}
+        asset_name: ${{ steps.nml_archive.outputs.archive }}
+        asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,20 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload --username __token__ dist/*.whl dist/*.tar.gz
+        version=`python setup.py --version`
+        archive=`echo "nml-$version.tar.gz"`
+        echo "::set-output name=archive::$archive"
+      id: nml_source_archive
 
+    - name: Publish source tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./dist/${{ steps.nml_source_archive.outputs.archive }}
+        asset_name: ${{ steps.nml_source_archive.outputs.archive }}
+        asset_content_type: application/gzip
 
   release-windows:
     name: Windows release

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/*
+dist/*
 **/__pycache__/*
 nml/__version__.py
 nml/generated/parsetab.py

--- a/README.md
+++ b/README.md
@@ -139,9 +139,8 @@ The audience is NewGRF authors and downstream package maintainers, so don't list
 For large releases and/or if there are deprecations or nml syntax changes, provide more detailed release notes.
 Example: https://github.com/OpenTTD/nml/blob/master/docs/changelog.txt
 4. Publish a new release using the release tool in the GitHub project: https://github.com/OpenTTD/nml/releases/new
-5. GitHub Actions will build the release and publish to PyPI (the Python package index).
+5. GitHub Actions will build the release, publish to PyPI (the Python package index) and also to the GitHub release.
 6. GitHub Actions will publish the Windows binary to the GitHub release.
-Download the source tarball, then upload it to the GitHub release (helpful for debian package maintainers).
 7. (Optional) announce the release in places such as https://www.tt-forums.net/viewforum.php?f=68
 
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ For large releases and/or if there are deprecations or nml syntax changes, provi
 Example: https://github.com/OpenTTD/nml/blob/master/docs/changelog.txt
 4. Publish a new release using the release tool in the GitHub project: https://github.com/OpenTTD/nml/releases/new
 5. GitHub Actions will build the release and publish to PyPI (the Python package index).
-6. GitHub Actions will publish the Windows binary as an artefact.
-Download this, then upload it to the GitHub release.
+6. GitHub Actions will publish the Windows binary to the GitHub release.
 7. (Optional) announce the release in places such as https://www.tt-forums.net/viewforum.php?f=68
 
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Example: https://github.com/OpenTTD/nml/blob/master/docs/changelog.txt
 4. Publish a new release using the release tool in the GitHub project: https://github.com/OpenTTD/nml/releases/new
 5. GitHub Actions will build the release and publish to PyPI (the Python package index).
 6. GitHub Actions will publish the Windows binary to the GitHub release.
+Download the source tarball, then upload it to the GitHub release (helpful for debian package maintainers).
 7. (Optional) announce the release in places such as https://www.tt-forums.net/viewforum.php?f=68
 
 


### PR DESCRIPTION
Split up the release workflow into separate jobs, as trying to keep them together was just making things difficult to read.
Now builds source tarball with MacOS to get that LF line ending goodness

Seems to still work - https://github.com/LordAro/nml/actions/runs/93337764 - they all failed, but that's just because they don't have permission to upload to PyPI :)