### PR TITLE
Fix: Enable the example object to be placed in-game

### DIFF
--- a/examples/object/example_object.nml
+++ b/examples/object/example_object.nml
@@ -145,7 +145,9 @@ item(FEAT_OBJECTS, company_land) {
 	}
 	graphics {
 		purchase:            company_land_purchase_switch;
-		tile_check:          return 0;
+		// Allow placement on any land tile (the default prevents building on 'steep' slopes).
+		// The object cannot be placed on water despite this, because OBJ_FLAG_ON_WATER isn't set.
+		tile_check:          return CB_RESULT_LOCATION_ALLOW;
 		additional_text:     return string(STR_NAME_COMPANY_LAND);
 		company_land_terrain_switch;
 	}


### PR DESCRIPTION
Returning 0 from tile_check means to disallow placement, and show the
 user the first string in the language file. This is not a useful
 behaviour, nor a good example for grf authors.

Allowing placement makes more sense!