### PR TITLE
Doc: Remove broken code from industry example.

### DIFF
--- a/examples/industry/example_industry.nml
+++ b/examples/industry/example_industry.nml
@@ -4,6 +4,8 @@
  * detail, refer to the object-specific reference in the documentation.
  *
  * This version shows only how to modify a built-in industry.
+ * The online documentation has more examples.
+ * In particular, for more-complex production behaviour see https://newgrf-specs.tt-wiki.net/wiki/NML:Produce
  *
  * Apart from this file, you will also need the following
  * - Language files, to be placed in the 'lang' folder.
@@ -37,10 +39,6 @@ cargotable {
  	PASS, COAL, MAIL, OIL_, LVST, GOOD, GRAI, WOOD, IORE, STEL, VALU
 }
 
-produce(test_produce1, [COAL: STORE_TEMP(5, 0); IORE: STORE_TEMP(7, 1);], [STEL: 5;], 1)
-produce(test_produce2, [COAL: 5; IORE: 7;], [STEL: 5;])
-produce(test_produce3, [], [], 0)
-
 /*
 * This example extends the cargos accepted and produce by the default temperate factory.
 */
@@ -62,7 +60,6 @@ item(FEAT_INDUSTRIES, factory) {
         ];
     }
     graphics {
- 		produce_cargo_arrival: test_produce1;
         extra_text_industry: extra_text_switch;
     }
 }


### PR DESCRIPTION
The removed code triggered an infinite loop in the production callback,
 without really illustrating how to achieve something useful.

Add a link to the wiki, which has a working example of how to use
 `produce` blocks.