### PR TITLE
Add: Ignore unreferenced named parameters

### DIFF
--- a/nml/actions/actionD.py
+++ b/nml/actions/actionD.py
@@ -94,6 +94,9 @@ class ParameterAssignment(base_statement.BaseStatement):
             if not self.param.can_assign():
                 raise generic.ScriptError("Trying to assign a value to the read-only variable '{}'".format(self.param.name), self.param.pos)
         elif isinstance(self.param, expression.Identifier):
+            if global_constants.identifier_refcount[self.param.value] == 0:
+                generic.print_warning("Named parameter '{}' is not referenced, ignoring.".format(self.param.value), self.param.pos)
+                return
             num = action6.free_parameters.pop_unique(self.pos)
             global_constants.named_parameters[self.param.value] = num
         elif not isinstance(self.param, expression.Parameter):
@@ -315,6 +318,9 @@ def parse_actionD(assignment):
     if isinstance(assignment.param, expression.SpecialParameter):
         assignment.param, assignment.value = assignment.param.to_assignment(assignment.value)
     elif isinstance(assignment.param, expression.Identifier):
+        if global_constants.identifier_refcount[assignment.param.value] == 0:
+            # Named parameter is not referenced, ignoring
+            return []
         assignment.param = expression.Parameter(expression.ConstantNumeric(global_constants.named_parameters[assignment.param.value]), assignment.param.pos)
     assert isinstance(assignment.param, expression.Parameter)
 

--- a/nml/expression/identifier.py
+++ b/nml/expression/identifier.py
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with NML; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
-from nml import generic
+from nml import generic, global_constants
 from .base_expression import Expression, ConstantNumeric
 from .string_literal import StringLiteral
 
@@ -42,6 +42,10 @@ class Identifier(Expression):
     def __init__(self, value, pos = None):
         Expression.__init__(self, pos)
         self.value = value
+        if value in global_constants.identifier_refcount:
+            global_constants.identifier_refcount[value] += 1
+        else:
+            global_constants.identifier_refcount[value] = 0
 
     def debug_print(self, indentation):
         generic.print_dbg(indentation, 'ID:', self.value)

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -1233,6 +1233,7 @@ is_default_tramtype_table = True
 # if no tramtype_table is provided, OpenTTD sets all vehicles to ELRL
 tramtype_table = {'ELRL': 0}
 
+identifier_refcount = {}
 item_names = {}
 settings = {}
 named_parameters = {}


### PR DESCRIPTION
When a named parameter is defined, it consumes an actionD register, even if it's never accessed later.

This PR solves that by reference counting all identifiers, and assign an actionD register only if it's needed.

The check is not recursive, a named parameter referenced only by an unreferenced one won't be ignored. Same for write only named parameters written multiple times. But I think these cases should not be common.
