### PR TITLE
Codechange: Make id_list callbacks take a 'name' argument

### DIFF
--- a/nml/actions/action2layout.py
+++ b/nml/actions/action2layout.py
@@ -258,7 +258,7 @@ class Action2LayoutSprite:
         if len(sg_ref.param_list) == 0:
             offset = None
         elif len(sg_ref.param_list) == 1:
-            id_dicts = [(spriteset.labels, lambda val, pos: expression.ConstantNumeric(val, pos))]
+            id_dicts = [(spriteset.labels, lambda name, val, pos: expression.ConstantNumeric(val, pos))]
             offset = action2var.reduce_varaction2_expr(sg_ref.param_list[0], self.feature, self.extra_dicts + id_dicts)
             if isinstance(offset, expression.ConstantNumeric):
                 generic.check_range(offset.value, 0, len(real_sprite.parse_sprite_data(spriteset)) - 1, "offset within spriteset", sg_ref.pos)
@@ -381,7 +381,7 @@ def get_layout_action2s(spritelayout, feature, spr_pos):
         reg = action2var.VarAction2LayoutParam()
         param_registers.append(reg)
         param_map[param.value] = reg
-    param_map = (param_map, lambda value, pos: action2var.VarAction2LoadLayoutParam(value))
+    param_map = (param_map, lambda name, value, pos: action2var.VarAction2LoadLayoutParam(value))
     spritelayout.register_map[feature] = param_registers
 
     # Reduce all expressions, can't do that earlier as feature is not known

--- a/nml/expression/functioncall.py
+++ b/nml/expression/functioncall.py
@@ -626,7 +626,7 @@ def builtin_palette_2cc(name, args, pos):
     col2 = BinOp(nmlop.MUL, args[1], ConstantNumeric(16), pos)
     col12 = BinOp(nmlop.ADD, col2, args[0], pos)
     # Base sprite is not a constant
-    base = global_constants.patch_variable(global_constants.patch_variables['base_sprite_2cc'], pos)
+    base = global_constants.patch_variable('base_sprite_2cc', global_constants.patch_variables['base_sprite_2cc'], pos)
 
     return BinOp(nmlop.ADD, col12, base, pos)
 

--- a/nml/expression/identifier.py
+++ b/nml/expression/identifier.py
@@ -19,9 +19,12 @@ from .string_literal import StringLiteral
 
 ignore_all_invalid_ids = False
 
-def default_id_func(x, pos):
+def default_id_func(name, x, pos):
     """
     Default id conversion function.
+
+    @param name: Key in the containing dictionary.
+    @type  name: Any, unused (to match other id_dicts callbacks)
 
     @param x: Value to convert.
     @type  x: C{str}, C{int}, or C{float}
@@ -32,6 +35,7 @@ def default_id_func(x, pos):
     @return: Expression of the id.
     @rtype:  L{Expression}
     """
+    del name  # unused
     if isinstance(x, str):
         return StringLiteral(x, pos)
     else:
@@ -59,9 +63,9 @@ class Identifier(Expression):
             if self.value in id_d:
                 if search_func_ptr:
                     # Do not reduce function pointers, since they have no (numerical) value
-                    return func(id_d[self.value], self.pos)
+                    return func(self.value, id_d[self.value], self.pos)
                 else:
-                    return func(id_d[self.value], self.pos).reduce(id_dicts)
+                    return func(self.value, id_d[self.value], self.pos).reduce(id_dicts)
 
         if unknown_id_fatal and not ignore_all_invalid_ids:
             raise generic.ScriptError("Unrecognized identifier '" + self.value + "' encountered", self.pos)

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -1053,8 +1053,8 @@ def global_param_read(info, pos):
     if 'function' in info: return info['function'](param, info)
     return param
 
-def param_from_info(info, pos):
-    return expression.SpecialParameter(generic.reverse_lookup(global_parameters, info), info, global_param_write, global_param_read, False, pos)
+def param_from_info(name, info, pos):
+    return expression.SpecialParameter(name, info, global_param_write, global_param_read, False, pos)
 
 global_parameters = {
     'climate'                            : {'num': 0x83, 'size': 1},
@@ -1083,8 +1083,8 @@ def misc_bit_write(info, expr, pos):
 def misc_bit_read(info, pos):
     return expression.BinOp(nmlop.HASBIT, expression.Parameter(expression.ConstantNumeric(info['param'], pos), pos), expression.ConstantNumeric(info['bit'], pos), pos)
 
-def misc_grf_bit(info, pos):
-    return expression.SpecialParameter(generic.reverse_lookup(misc_grf_bits, info), info, misc_bit_write, misc_bit_read, True, pos)
+def misc_grf_bit(name, info, pos):
+    return expression.SpecialParameter(name, info, misc_bit_write, misc_bit_read, True, pos)
 
 misc_grf_bits = {
     'traffic_side'                       : {'param': 0x86, 'bit': 4},
@@ -1147,8 +1147,8 @@ def patch_variable_read(info, pos):
         expr = info['function'](expr, info)
     return expr
 
-def patch_variable(info, pos):
-    return expression.SpecialParameter(generic.reverse_lookup(patch_variables, info), info, None, patch_variable_read, False, pos)
+def patch_variable(name, info, pos):
+    return expression.SpecialParameter(name, info, None, patch_variable_read, False, pos)
 
 patch_variables = {
     'starting_year'           : {'num': 0x0B, 'start':  0, 'size': 32, 'function': add_1920},
@@ -1169,8 +1169,8 @@ patch_variables = {
 def config_flag_read(bit, pos):
     return expression.SpecialCheck((0x01, r'\70'), 0x85, (0, 1), bit, "PatchFlag({})".format(bit), varsize = 1, pos = pos)
 
-def config_flag(info, pos):
-    return expression.SpecialParameter(generic.reverse_lookup(config_flags, info), info, None, config_flag_read, True, pos)
+def config_flag(name, info, pos):
+    return expression.SpecialParameter(name, info, None, config_flag_read, True, pos)
 
 config_flags = {
     'long_bridges'            : 0x0F,
@@ -1198,25 +1198,27 @@ def unified_maglev_read(info, pos):
     shifted_bit1 = expression.BinOp(nmlop.SHIFT_LEFT, bit1, expression.ConstantNumeric(1))
     return expression.BinOp(nmlop.OR, shifted_bit1, bit0)
 
-def unified_maglev(info, pos):
-    return expression.SpecialParameter(generic.reverse_lookup(unified_maglev_var, info), info, None, unified_maglev_read, False, pos)
+def unified_maglev(name, info, pos):
+    return expression.SpecialParameter(name, info, None, unified_maglev_read, False, pos)
 
 unified_maglev_var = {
     'unified_maglev' : 0,
 }
 
-def setting_from_info(info, pos):
-    return expression.SpecialParameter(generic.reverse_lookup(settings, info), info, global_param_write, global_param_read, False, pos)
+def setting_from_info(name, info, pos):
+    return expression.SpecialParameter(name, info, global_param_write, global_param_read, False, pos)
 
-def item_to_id(item, pos):
+def item_to_id(name, item, pos):
     if not isinstance(item.id, expression.ConstantNumeric):
-        raise generic.ScriptError("Referencing item '{}' with a non-constant id is not possible.".format(item.name), pos)
+        raise generic.ScriptError("Referencing item '{}' with a non-constant id is not possible.".format(name), pos)
     return expression.ConstantNumeric(item.id.value, pos)
 
-def param_from_name(info, pos):
+def param_from_name(name, info, pos):
+    del name # unused; to match other id_list callbacks
     return expression.Parameter(expression.ConstantNumeric(info), pos)
 
-def create_spritegroup_ref(info, pos):
+def create_spritegroup_ref(name, info, pos):
+    del name # unused; to match other id_list callbacks
     return expression.SpriteGroupRef(expression.Identifier(info), [], pos)
 
 cargo_numbers = {}


### PR DESCRIPTION
This avoids a lot of nonsense with reverse_lookup().