### PR TITLE
Switches optimisations improvements and fixes

### DIFF
--- a/nml/actions/action2.py
+++ b/nml/actions/action2.py
@@ -329,6 +329,7 @@ def make_sprite_group_class(cls_is_spriteset, cls_is_referenced, cls_has_explici
             self.name = name
             self.num_params = num_params
             self.used_sprite_sets = []
+            self.optimised = None
 
         def register_names(self):
             if cls_is_relocatable and cls_is_referenced:
@@ -383,7 +384,7 @@ def make_sprite_group_class(cls_is_spriteset, cls_is_referenced, cls_has_explici
                         # Add the features from all calling blocks to the set
                         self.feature_set.update(n.feature_set)
 
-                if len(self._referencing_nodes) == 0:
+                if len(self._referencing_nodes) == 0 and not self.optimised:
                     # if we can be 'not used', there ought to be a way to refer to this block
                     assert self.name is not None
                     generic.print_warning("Block '{}' is not referenced, ignoring.".format(self.name.value), self.pos)
@@ -410,6 +411,15 @@ def make_sprite_group_class(cls_is_spriteset, cls_is_referenced, cls_has_explici
             """
 
             return self._referencing_nodes
+
+        def optimise(self):
+            """
+            Optimise this sprite group.
+
+            @return: True iff this sprite group has been optimised
+            @rtype: C{bool}
+            """
+            return False
 
         def collect_references(self):
             """

--- a/nml/ast/switch.py
+++ b/nml/ast/switch.py
@@ -78,11 +78,19 @@ class Switch(switch_base_class):
     def optimise(self):
         if self.optimised:
             return True
+        if isinstance(self.expr, expression.ConstantNumeric):
+            for r in self.body.ranges[:]:
+                if r.min.value <= self.expr.value <= r.max.value:
+                    generic.print_warning(
+                        "Block '{}' returns a constant, optimising.".format(self.name.value), self.pos
+                    )
+                    self.optimised = r.result.value
+                    return True
         if (
             self.expr.is_read_only()
             and self.body.default is not None
             and self.body.default.value is not None
-            and len(self.body.ranges) == 0
+            and (len(self.body.ranges) == 0 or isinstance(self.expr, expression.ConstantNumeric))
         ):
             generic.print_warning("Block '{}' returns a constant, optimising.".format(self.name.value), self.pos)
             self.optimised = self.body.default.value

--- a/nml/ast/switch.py
+++ b/nml/ast/switch.py
@@ -96,6 +96,9 @@ class Switch(switch_base_class):
                 all_refs += result.value.collect_references()
         return all_refs
 
+    def is_read_only(self):
+        return self.expr.is_read_only()
+
     def debug_print(self, indentation):
         generic.print_dbg(
             indentation, "Switch, Feature = {:d}, name = {}".format(next(iter(self.feature_set)), self.name.value)

--- a/nml/expression/spritegroup_ref.py
+++ b/nml/expression/spritegroup_ref.py
@@ -92,6 +92,12 @@ class SpriteGroupRef(Expression):
     def collect_references(self):
         return list(chain([self], *(p.collect_references() for p in self.param_list)))
 
+    def is_read_only(self):
+        if self.name.value != "CB_FAILED":
+            spritegroup = action2.resolve_spritegroup(self.name)
+            return spritegroup.is_read_only()
+        return True
+
     def type(self):
         if self.is_procedure:
             return Type.INTEGER


### PR DESCRIPTION
Before this rewrite, an optimised switch could output a `returns a constant, optimising` warning at each usage location, and a bogus `is not referenced, ignoring` warning. Now only one `returns a constant, optimising` happens.

There was also an bug in `is_read_only`.