### PR TITLE
Fix: regression failure with Pillow 8.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     ext_modules=[Extension("nml_lz77", ["nml/_lz77.c"], optional=True)],
     python_requires=">=3.5",
     install_requires=[
-        "Pillow>=3.4",
+        "Pillow>=3.4,<8.1.0",
         "ply",
     ],
     cmdclass={"build_py": NMLBuildPy},


### PR DESCRIPTION
A [change](https://github.com/python-pillow/Pillow/commit/2f409261eb1228e166868f8f0b5da5cda52e55bf) in Pillow 8.1.0 (release 4 days ago) triggers `OSError: buffer overrun when reading image file` for opengfx_generic_trams1.pcx (371x150) and `OSError: image file is truncated (0 bytes not processed)` for opengfx_trains_start.pcx (409x210)

I don't really know if it's a bug in Pillow, but I fixed the issue by croping first file to 370x150 and second file to 408x210.