### PR TITLE
Add support for recent NewGRF additions

### DIFF
--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -563,7 +563,7 @@ def industry_town_count(name, args, pos, info):
     return (args[0], extra_params)
 
 def industry_cargotype(name, args, pos, info):
-    return (expression.functioncall.builtin_resolve_typelabel(name, args, pos), [])
+    return (expression.functioncall.builtin_resolve_typelabel(name, args, pos, table_name="cargotype"), [])
 
 varact2vars60x_industries = {
     'nearby_tile_industry_tile_id' : {'var': 0x60, 'start':  0, 'size': 16, 'param_function': unsigned_tile_offset},

--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -148,6 +148,7 @@ varact2vars_vehicles = {
     'vehicle_is_offered'               : {'var': 0x48, 'start':  2, 'size':  1},
     'build_year'                       : {'var': 0x49, 'start':  0, 'size': 32},
     'vehicle_is_potentially_powered'   : {'var': 0x4A, 'start':  8, 'size':  1},
+    'tile_has_catenary'                : {'var': 0x4A, 'start':  9, 'size':  1},
     'date_of_last_service'             : {'var': 0x4B, 'start':  0, 'size': 32},
     'position_in_articulated_veh'          : {'var': 0x4D, 'start':  0, 'size':  8},
     'position_in_articulated_veh_from_end' : {'var': 0x4D, 'start':  8, 'size':  8},

--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -178,6 +178,7 @@ varact2vars_vehicles = {
 # Vehicle-type-specific variables
 
 varact2vars_trains = {
+    **varact2vars_vehicles,
     #0x4786 / 0x10000 is an approximation of 3.5790976, the conversion factor
     #for train speed
     'max_speed'           : {'var': 0x98, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x4786, 0x10000)},
@@ -186,9 +187,9 @@ varact2vars_trains = {
     'current_max_speed'   : {'var': 0x4C, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x4786, 0x10000)},
     'vehicle_is_in_depot' : {'var': 0xE2, 'start': 7, 'size':  1},
 }
-varact2vars_trains.update(varact2vars_vehicles)
 
 varact2vars_roadvehs = {
+    **varact2vars_vehicles,
     #0x23C3 / 0x10000 is an approximation of 7.1581952, the conversion factor
     #for road vehicle speed
     'max_speed'           : {'var': 0x98, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x23C3, 0x10000)},
@@ -198,9 +199,9 @@ varact2vars_roadvehs = {
     'current_max_speed'   : {'var': 0x4C, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x23C3, 0x10000)},
     'vehicle_is_in_depot' : {'var': 0xE2, 'start': 0, 'size':  8, 'value_function': value_equals(0xFE)},
 }
-varact2vars_roadvehs.update(varact2vars_vehicles)
 
 varact2vars_ships = {
+    **varact2vars_vehicles,
     #0x23C3 / 0x10000 is an approximation of 7.1581952, the conversion factor
     #for ship speed
     'max_speed'           : {'var': 0x98, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x23C3, 0x10000)},
@@ -208,9 +209,9 @@ varact2vars_ships = {
     'current_max_speed'   : {'var': 0x4C, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x23C3, 0x10000)},
     'vehicle_is_in_depot' : {'var': 0xE2, 'start': 7, 'size':  1},
 }
-varact2vars_ships.update(varact2vars_vehicles)
 
 varact2vars_aircraft = {
+    **varact2vars_vehicles,
     #0x3939 / 0x1000 is an approximation of 0.279617, the conversion factor
     #Note that the denominator has one less zero here!
     #for aircraft speed
@@ -219,7 +220,6 @@ varact2vars_aircraft = {
     'current_max_speed'   : {'var': 0x4C, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x3939, 0x1000)},
     'vehicle_is_in_depot' : {'var': 0xE6, 'start': 0, 'size':  8, 'value_function': value_equals(0)},
 }
-varact2vars_aircraft.update(varact2vars_vehicles)
 
 def signed_byte_parameter(name, args, pos, info):
     # Convert to a signed byte by AND-ing with 0xFF
@@ -272,6 +272,7 @@ varact2vars60x_base_stations = {
 }
 
 varact2vars_stations = {
+    **varact2vars_base_stations,
     # Vars 40, 41, 46, 47, 49 are implemented as 60+x vars,
     # except for the 'tile type' part which is always the same anyways
     'tile_type'                : {'var': 0x40, 'start': 24, 'size': 4},
@@ -288,7 +289,6 @@ varact2vars_stations = {
     'rail_present'             : {'var': 0x45, 'start':  8, 'size': 8},
     'animation_frame'          : {'var': 0x4A, 'start':  0, 'size': 8},
 }
-varact2vars_stations.update(varact2vars_base_stations)
 
 # Mapping of param values for platform_xx vars to variable numbers
 mapping_platform_param = {
@@ -319,6 +319,7 @@ def platform_info_fix_var(var, info):
     return var
 
 varact2vars60x_stations = {
+    **varact2vars60x_base_stations,
     'nearby_tile_animation_frame'   : {'var': 0x66, 'start':  0, 'size': 32, 'param_function': signed_tile_offset},
     'nearby_tile_slope'             : {'var': 0x67, 'start':  0, 'size':  5, 'param_function': signed_tile_offset},
     'nearby_tile_is_water'          : {'var': 0x67, 'start':  9, 'size':  1, 'param_function': signed_tile_offset},
@@ -347,7 +348,6 @@ varact2vars60x_stations = {
     'platform_number_from_middle'   : {'var': 0x00, 'start':  4, 'size':  4, 'param_function': platform_info_param, 'middle': True, # 'middle' is used by platform_info_param
                                             'value_function': lambda var, info: value_sign_extend(platform_info_fix_var(var, info), info)},
 }
-varact2vars60x_stations.update(varact2vars60x_base_stations)
 
 #
 # Canals (feature 0x05)
@@ -604,10 +604,12 @@ varact2vars60x_industries = {
 #
 
 varact2vars_airports = {
+    **varact2vars_base_stations,
     'layout' : {'var': 0x40, 'start': 0, 'size': 32},
 }
-varact2vars_airports.update(varact2vars_base_stations)
-varact2vars60x_airports = varact2vars60x_base_stations
+varact2vars60x_airports = {
+    **varact2vars60x_base_stations,
+}
 
 #
 # New Signals (feature 0x0E) are not implemented in OpenTTD

--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -231,6 +231,15 @@ def signed_byte_parameter(name, args, pos, info):
     ret = nmlop.AND(args[0], 0xFF, pos).reduce()
     return (ret, [])
 
+def vehicle_railtype(name, args, pos, info):
+    return (expression.functioncall.builtin_resolve_typelabel(name, args, pos, table_name="railtype"), [])
+
+def vehicle_roadtype(name, args, pos, info):
+    return (expression.functioncall.builtin_resolve_typelabel(name, args, pos, table_name="roadtype"), [])
+
+def vehicle_tramtype(name, args, pos, info):
+    return (expression.functioncall.builtin_resolve_typelabel(name, args, pos, table_name="tramtype"), [])
+
 varact2vars60x_vehicles = {
     'count_veh_id'        : {'var': 0x60, 'start':  0, 'size': 8},
     'other_veh_curv_info' : {'var': 0x62, 'start':  0, 'size': 4, 'param_function':signed_byte_parameter, 'value_function':value_sign_extend},
@@ -238,6 +247,25 @@ varact2vars60x_vehicles = {
     'other_veh_x_offset'  : {'var': 0x62, 'start':  8, 'size': 8, 'param_function':signed_byte_parameter, 'value_function':value_sign_extend},
     'other_veh_y_offset'  : {'var': 0x62, 'start': 16, 'size': 8, 'param_function':signed_byte_parameter, 'value_function':value_sign_extend},
     'other_veh_z_offset'  : {'var': 0x62, 'start': 24, 'size': 8, 'param_function':signed_byte_parameter, 'value_function':value_sign_extend},
+}
+
+varact2vars60x_trains = {
+    **varact2vars60x_vehicles,
+    # Var 0x63 bit 0 is only useful when testing multiple bits at once. On its own it is already covered by railtype_available().
+    'tile_supports_railtype' : {'var': 0x63, 'start':  1, 'size': 1, 'param_function':vehicle_railtype},
+    'tile_powers_railtype'   : {'var': 0x63, 'start':  2, 'size': 1, 'param_function':vehicle_railtype},
+    'tile_is_railtype'       : {'var': 0x63, 'start':  3, 'size': 1, 'param_function':vehicle_railtype},
+}
+
+varact2vars60x_roadvehs = {
+    **varact2vars60x_vehicles,
+    # Var 0x63 bit 0 is only useful when testing multiple bits at once. On its own it is already covered by road/tramtype_available().
+    'tile_supports_roadtype' : {'var': 0x63, 'start':  1, 'size': 1, 'param_function':vehicle_roadtype},
+    'tile_supports_tramtype' : {'var': 0x63, 'start':  1, 'size': 1, 'param_function':vehicle_tramtype},
+    'tile_powers_roadtype'   : {'var': 0x63, 'start':  2, 'size': 1, 'param_function':vehicle_roadtype},
+    'tile_powers_tramtype'   : {'var': 0x63, 'start':  2, 'size': 1, 'param_function':vehicle_tramtype},
+    'tile_is_roadtype'       : {'var': 0x63, 'start':  3, 'size': 1, 'param_function':vehicle_roadtype},
+    'tile_is_tramtype'       : {'var': 0x63, 'start':  3, 'size': 1, 'param_function':vehicle_tramtype},
 }
 
 #
@@ -752,9 +780,9 @@ varact2vars_towns = {
 
 
 varact2vars[0x00] = varact2vars_trains
-varact2vars60x[0x00] = varact2vars60x_vehicles
+varact2vars60x[0x00] = varact2vars60x_trains
 varact2vars[0x01] = varact2vars_roadvehs
-varact2vars60x[0x01] = varact2vars60x_vehicles
+varact2vars60x[0x01] = varact2vars60x_roadvehs
 varact2vars[0x02] = varact2vars_ships
 varact2vars60x[0x02] = varact2vars60x_vehicles
 varact2vars[0x03] = varact2vars_aircraft

--- a/nml/actions/action5.py
+++ b/nml/actions/action5.py
@@ -78,7 +78,7 @@ action5_table = {
     "AQUEDUCTS": (0x12, 8, Action5BlockType.OFFSET),
     "AUTORAIL": (0x13, 55, Action5BlockType.OFFSET),
     "FLAGS": (0x14, 36, Action5BlockType.OFFSET),
-    "OTTD_GUI": (0x15, 184, Action5BlockType.OFFSET),
+    "OTTD_GUI": (0x15, 186, Action5BlockType.OFFSET),
     "AIRPORT_PREVIEW": (0x16, 9, Action5BlockType.OFFSET),
     "RAILTYPE_TUNNELS": (0x17, 16, Action5BlockType.OFFSET),
     "OTTD_RECOLOUR": (0x18, 1, Action5BlockType.OFFSET),

--- a/nml/expression/functioncall.py
+++ b/nml/expression/functioncall.py
@@ -457,25 +457,24 @@ def builtin_str2number(name, args, pos):
 
 
 @builtins("cargotype", "railtype", "roadtype", "tramtype")
-def builtin_resolve_typelabel(name, args, pos):
+def builtin_resolve_typelabel(name, args, pos, table_name=None):
     """
     {cargo,rail,road,tram}type(label) builtin functions.
 
     Also used from some Action2Var variables to resolve cargo labels.
     """
     tracktype_funcs = {
+        "cargotype": global_constants.cargo_numbers,
         "railtype": global_constants.railtype_table,
         "roadtype": global_constants.roadtype_table,
         "tramtype": global_constants.tramtype_table,
     }
-    if name in tracktype_funcs:
-        table = tracktype_funcs[name]
+
+    if not table_name:
         table_name = name
-    else:
-        # Resolve cargo ID for all other names: either `cargotype(label)`
-        #  or action2var_variables such as `this_month_production(label)`.
-        table = global_constants.cargo_numbers
-        table_name = "cargo"
+    table = tracktype_funcs[table_name]
+    if table_name == "cargotype":
+        table_name = "cargo"  # NML syntax uses "cargotable" and "railtypetable"
 
     if len(args) != 1:
         raise generic.ScriptError(name + "() must have 1 parameter", pos)

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -1224,6 +1224,7 @@ config_flags = {
     "dynamic_engines"         : 0x78,
     "variable_runningcosts"   : 0x7E,
     "256_persistent_registers": 0x80,
+    "inflation"               : 0x81,
 }
 # fmt: on
 

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -393,6 +393,7 @@ constant_numbers = {
     "IND_FLAG_DO_NOT_FORCE_INSTANCE_AT_MAP_GENERATION" : 16,
     "IND_FLAG_ALLOW_CLOSING_LAST_INSTANCE"             : 17,
     "IND_FLAG_LONG_CARGO_TYPE_LISTS"                   : 18,
+    "IND_FLAG_DO_NOT_CLAMP_PASSENGER_PRODUCTION"       : 19,
 
     # flags for builtin function industry_type(..)
     "IND_TYPE_OLD"             : 0,


### PR DESCRIPTION
Adds support for some recent NewGRF additions, those that I know what they do.

I am a bit worried about adding such a generic name like "inflation" to the global namespace. But I have no better idea either.