### PR TITLE
Add: Ground sprite constants for  partially cleared tiles

### DIFF
--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -282,6 +282,9 @@ constant_numbers = {
     # ground sprite IDs
     "GROUNDSPRITE_CONCRETE"    : 1420,
     "GROUNDSPRITE_CLEARED"     : 3924,
+    "GROUNDSPRITE_GRASS_1_3"   : 3943,
+    "GROUNDSPRITE_GRASS_2_3"   : 3962,
+    "GROUNDSPRITE_GRASS_3_3"   : 3981,
     "GROUNDSPRITE_NORMAL"      : 3981,
     "GROUNDSPRITE_WATER"       : 4061,
     "GROUNDSPRITE_SNOW_1_4"    : 4493,

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -285,6 +285,7 @@ constant_numbers = {
     "GROUNDSPRITE_GRASS_1_3"   : 3943,
     "GROUNDSPRITE_GRASS_2_3"   : 3962,
     "GROUNDSPRITE_GRASS_3_3"   : 3981,
+    "GROUNDSPRITE_GRASS"       : 3981,
     "GROUNDSPRITE_NORMAL"      : 3981,
     "GROUNDSPRITE_WATER"       : 4061,
     "GROUNDSPRITE_SNOW_1_4"    : 4493,
@@ -293,6 +294,7 @@ constant_numbers = {
     "GROUNDSPRITE_SNOW_4_4"    : 4550,
     "GROUNDSPRITE_SNOW"        : 4550,
     "GROUNDSPRITE_DESERT_1_2"  : 4512,
+    "GROUNDSPRITE_DESERT_2_2"  : 4550,
     "GROUNDSPRITE_DESERT"      : 4550,
 
     # general CB for rerandomizing


### PR DESCRIPTION
This PR adds two new ground sprite constants for "partially cleared" tiles, eg the ones that will gradually appear with more grass over time after bulldozing a tile to the fully cleared state.

I wanted to reuse these tiles for a "swamp" setting that I'm building, and figured it was more of an oversight than a feature that they were not part of the constants. Correct me if I'm wrong!