### PR TITLE
Change: Display input filename

### DIFF
--- a/nml/main.py
+++ b/nml/main.py
@@ -378,7 +378,7 @@ def nml(
     """
     generic.OnlyOnce.clear()
 
-    generic.print_progress("Reading ...")
+    generic.print_progress("Reading {} ...".format(input_filename or "standard input"))
 
     try:
         script = inputfile.read()


### PR DESCRIPTION
As suggested in #194, this replaces `Reading ...` message with `Reading filename.nml ...` or `Reading standard input ...` depending on whether an input filename was given.

Closes #194.