### PR TITLE
Fix #204: Consider string() as numeric constant when optimising switches

### DIFF
--- a/nml/ast/switch.py
+++ b/nml/ast/switch.py
@@ -100,6 +100,7 @@ class Switch(switch_base_class):
             self.optimised
             and not isinstance(self.optimised, expression.ConstantNumeric)
             and not isinstance(self.optimised, expression.SpriteGroupRef)
+            and not isinstance(self.optimised, expression.String)
         ):
             self.expr = self.optimised
             self.body.ranges = []
@@ -381,6 +382,7 @@ class RandomSwitch(switch_base_class):
             and (
                 isinstance(self.choices[0].result.value, expression.ConstantNumeric)
                 or isinstance(self.choices[0].result.value, expression.SpriteGroupRef)
+                or isinstance(self.choices[0].result.value, expression.String)
             )
         ):
             generic.print_warning("Block '{}' returns a constant, optimising.".format(self.name.value), self.pos)


### PR DESCRIPTION
`self.optimised` is used as a replacement in the caller, but for complex expressions a return action is then created when parsing caller's results and this return action uses caller's scope instead callee's one, that was the first bug (fixed with https://github.com/OpenTTD/nml/commit/597685d67869554a5dd6e390ca2be72c78448ecf).
So instead, now the original callee is rewritten like the return action (but with the correct scope) and `string()` was catch in the rewrite, causing their special handling as result values to be ignored.

`string()` return values are similar to numeric constant, they don't trigger the creation of a return action. So there's no need to rewrite switches for them.