### PR TITLE
Clean up language definitions

### DIFF
--- a/nml/grfstrings.py
+++ b/nml/grfstrings.py
@@ -860,7 +860,6 @@ LANG_INFOS = [
     ("zh_TW", 0x0C, 1),
 ]
 LANG_NAMES = {lng[0]: lng[1] for lng in LANG_INFOS}
-LANG_PLURALS = {lng[1]: lng[2] for lng in LANG_INFOS}
 
 
 class Language:
@@ -1090,7 +1089,6 @@ class Language:
         if value < 0 or value >= 0x7F:
             raise generic.ScriptError("Invalid grflangid", pos)
         self.langid = value
-        self.check_expected_plural(None)
 
     def handle_plural(self, data, pos):
         """
@@ -1109,26 +1107,6 @@ class Language:
         if value < 0 or value > NUM_PLURAL_FORMS:
             raise generic.ScriptError("Invalid plural form", pos)
         self.plural = value
-        self.check_expected_plural(pos)
-
-    def check_expected_plural(self, pos):
-        """
-        Check whether the provided plural form of the language file
-        matches with the expected value for that language.
-
-        If not, raise an error.
-
-        @param pos: Position of the ##plural line, if position is available.
-        @type  pos: L{Position}
-        """
-        if self.plural is None or self.langid is None:
-            return
-
-        expected = LANG_PLURALS.get(self.langid)
-        if expected is not None and self.plural != expected:
-            msg = "Language with language id 0x{:02x} has plural form {:d} while the language uses plural form {:d}."
-            msg = msg.format(self.langid, self.plural, expected)
-            raise generic.ScriptError(msg, pos)
 
     def handle_gender(self, data, pos):
         """

--- a/nml/grfstrings.py
+++ b/nml/grfstrings.py
@@ -778,7 +778,7 @@ def isint(x, base=10):
         return False
 
 
-NUM_PLURAL_FORMS = 13
+NUM_PLURAL_FORMS = 14
 
 CHOICE_LIST_ITEM = {"unicode": r"\UE09A\10", "ascii": r"\9A\10"}
 CHOICE_LIST_DEFAULT = {"unicode": r"\UE09A\11", "ascii": r"\9A\11"}
@@ -844,7 +844,7 @@ LANG_INFOS = [
     ("pl_PL", 0x30, 7),
     ("pt_BR", 0x37, 2),
     ("pt_PT", 0x36, 0),
-    ("ro_RO", 0x28, 0),
+    ("ro_RO", 0x28, 14),
     ("ru_RU", 0x07, 6),
     ("sk_SK", 0x16, 10),
     ("sl_SI", 0x2C, 8),
@@ -918,6 +918,7 @@ class Language:
             11: 2,
             12: 4,
             13: 4,
+            14: 3,
         }
         return num_plurals[self.plural]
 
@@ -1021,6 +1022,12 @@ class Language:
             if (val >= 3 and val <= 10) or (val >= 13 and val <= 19):
                 return 3
             return 4
+        if self.plural == 14:
+            if val == 1:
+                return 1
+            if val == 0 or 1 <= (val % 100) <= 19:
+                return 2
+            return 3
         raise AssertionError("Unknown plural type")
 
     def get_string(self, string, lang_id):

--- a/nml/grfstrings.py
+++ b/nml/grfstrings.py
@@ -792,75 +792,6 @@ STRING_ROTATE = {"unicode": r"\UE086", "ascii": r"\86"}
 STRING_PUSH_WORD = {"unicode": r"\UE09A\03\20\20", "ascii": r"\9A\03\20\20"}
 STRING_SELECT_CASE = {"unicode": r"\UE09A\0F", "ascii": r"\9A\0F"}
 
-# Information about languages, borrowed from OpenTTD.
-# (isocode name, grf langid, plural number)
-LANG_INFOS = [
-    ("af_ZA", 0x1B, 0),
-    ("ar_EG", 0x14, 1),
-    ("be_BY", 0x10, 6),
-    ("bg_BG", 0x18, 0),
-    ("ca_ES", 0x22, 0),
-    ("cs_CZ", 0x15, 10),
-    ("cv_RU", 0x0B, 0),
-    ("cy_GB", 0x0F, 0),
-    ("da_DK", 0x2D, 0),
-    ("de_DE", 0x02, 0),
-    ("el_GR", 0x1E, 2),
-    ("en_AU", 0x3D, 0),
-    ("en_GB", 0x01, 0),
-    ("en_US", 0x00, 0),
-    ("eo_EO", 0x05, 0),
-    ("es_ES", 0x04, 0),
-    ("et_EE", 0x34, 0),
-    ("eu_ES", 0x21, 0),
-    ("fa_IR", 0x62, 0),
-    ("fi_FI", 0x35, 0),
-    ("fo_FO", 0x12, 0),
-    ("fr_FR", 0x03, 2),
-    ("fy_NL", 0x32, 0),
-    ("ga_IE", 0x08, 4),
-    ("gd_GB", 0x13, 13),
-    ("gl_ES", 0x31, 0),
-    ("he_IL", 0x61, 0),
-    ("hr_HR", 0x38, 6),
-    ("hu_HU", 0x24, 2),
-    ("id_ID", 0x5A, 1),
-    ("io_IO", 0x06, 0),
-    ("is_IS", 0x29, 0),
-    ("it_IT", 0x27, 0),
-    ("ja_JP", 0x39, 1),
-    ("ko_KR", 0x3A, 11),
-    ("la_VA", 0x66, 0),
-    ("lb_LU", 0x23, 0),
-    ("lt_LT", 0x2B, 5),
-    ("lv_LV", 0x2A, 3),
-    ("mk_MK", 0x26, 0),
-    ("mr_IN", 0x11, 0),
-    ("ms_MY", 0x3C, 0),
-    ("mt_MT", 0x09, 12),
-    ("nb_NO", 0x2F, 0),
-    ("nl_NL", 0x1F, 0),
-    ("nn_NO", 0x0E, 0),
-    ("pl_PL", 0x30, 7),
-    ("pt_BR", 0x37, 2),
-    ("pt_PT", 0x36, 0),
-    ("ro_RO", 0x28, 14),
-    ("ru_RU", 0x07, 6),
-    ("sk_SK", 0x16, 10),
-    ("sl_SI", 0x2C, 8),
-    ("sr_RS", 0x0D, 6),
-    ("sv_SE", 0x2E, 0),
-    ("ta_IN", 0x0A, 0),
-    ("th_TH", 0x42, 1),
-    ("tr_TR", 0x3E, 1),
-    ("uk_UA", 0x33, 6),
-    ("ur_PK", 0x5C, 0),
-    ("vi_VN", 0x54, 1),
-    ("zh_CN", 0x56, 1),
-    ("zh_TW", 0x0C, 1),
-]
-LANG_NAMES = {lng[0]: lng[1] for lng in LANG_INFOS}
-
 
 class Language:
     """
@@ -1080,12 +1011,10 @@ class Language:
         if self.langid is not None:
             raise generic.ScriptError("grflangid already set", pos)
         lang_text = data.strip()
-        value = LANG_NAMES.get(lang_text)
-        if value is None:
-            try:
-                value = int(lang_text, 16)
-            except ValueError:
-                raise generic.ScriptError("Invalid grflangid {!r}".format(lang_text), pos)
+        try:
+            value = int(lang_text, 16)
+        except ValueError:
+            raise generic.ScriptError("Invalid grflangid {!r}".format(lang_text), pos)
         if value < 0 or value >= 0x7F:
             raise generic.ScriptError("Invalid grflangid", pos)
         self.langid = value

--- a/regression/lang/dutch.lng
+++ b/regression/lang/dutch.lng
@@ -1,4 +1,4 @@
-##grflangid nl_NL
+##grflangid 0x1F
 STR_REGRESSION_ERROR           :De wissels zijn bevroren, onze excuses voor het ongemak.
 STR_REGRESSION_CARE            :zorg
 STR_ANSWER                     :42

--- a/regression/lang/english.lng
+++ b/regression/lang/english.lng
@@ -1,4 +1,4 @@
-##grflangid en_GB
+##grflangid 0x01
 STR_NULL                       :
 STR_REGRESSION_NAME            :NML regression test
 STR_REGRESSION_DESC            :A test newgrf testing NML

--- a/regression/lang/us.lng
+++ b/regression/lang/us.lng
@@ -1,2 +1,2 @@
-##grflangid en_US
+##grflangid 0x00
 STR_STATIONS :US Stations


### PR DESCRIPTION
Recently some language definitions in OpenTTD changed.
* There is a new plural form 14.
* Romanian switched plural forms.
* New languages were added.

This PR adapts NML for that:
* The new plural form is added.
* NML maintained its own list of language ids and plural forms.
    * This list is removed.
    * NML allowed using an iso-code as ##grflangid. This was undocumented, and probably only used in the regression tests. **This features is removed.**
    * NML validated the plural forms of translations against an internal list of all known languages. It errored hard, if they differed. I have no idea why this validation was added. But it is unnecessary, and rejecting old NewGRF sources because some language switched plural forms, is unreasonable. **Thus, this validation is removed.**

In theory, the language info can be extracted/generated from https://translator.openttd.org/language-list
* Maintaining a list in NML sources is a burden, even when generated, and IMO not worth for the use cases.
* Fetching the list at run-time is unusual for a compiler. 
