### PR TITLE
Fix #209: Sign-extend value before cargo_profit callback result calculation

### DIFF
--- a/nml/actions/action3_callbacks.py
+++ b/nml/actions/action3_callbacks.py
@@ -216,6 +216,9 @@ def cargo_profit_value(value):
     # (amount * price_factor * (cb_result * 329 / 256)) / 256
     # This allows us to report a factor of 256 in the documentation, which makes a lot more sense than 199.804...
     # Not doing the division here would improve accuracy, but limits the range of the return value too much
+    # As cb_result is a 15bit signed value, we need to sign-extend it to 32bit before applying our math
+    value = nmlop.SHIFT_LEFT(value, 17)
+    value = nmlop.SHIFT_RIGHT(value, 17)
     value = nmlop.MUL(value, 329)
     return nmlop.DIV(value, 256)
 


### PR DESCRIPTION
NML does apply some calculation before returning the cargo_profit callback result.
But it does it on a 15bit signed value stored in 32bit without sign-extending, so of course the result for negative is wrong.

It's fixed in this PR by applying sign-extension to the 15bit value before doing other calculation.

Of course another option would be to just remove all this strange magical stuff ;)