### PR TITLE
Fix: LZ77 fallback is not compatible with python 3.9

### DIFF
--- a/nml/lz77.py
+++ b/nml/lz77.py
@@ -26,7 +26,7 @@ def _encode(data):
     @return: Compressed data.
     @rtype:  C{bytearray}
     """
-    stream = data.tostring()
+    stream = data.tobytes()
     position = 0
     output = array.array("B")
     literal_bytes = array.array("B")


### PR DESCRIPTION
`array.array.tostring()` has been renamed to `array.array.tobytes()` in python 3.2, and removed in python 3.9