### PR TITLE
Add: town var 0x41 'town_index'

### DIFF
--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -759,6 +759,7 @@ varact2vars_tramtype = {
 varact2vars_towns = {
     'is_city'                        : {'var': 0x40, 'start': 0, 'size': 1},
     'cities_enabled'                 : {'var': 0x40, 'start': 1, 'size': 1, 'value_function': lambda var, info: expression.Not(var, var.pos)},
+    'town_index'                     : {'var': 0x41, 'start': 0, 'size': 16},
     'population'                     : {'var': 0x82, 'start': 0, 'size': 16},
     'has_church'                     : {'var': 0x92, 'start': 1, 'size': 1},
     'has_stadium'                    : {'var': 0x92, 'start': 2, 'size': 1},


### PR DESCRIPTION
Per the comment at https://newgrf-specs.tt-wiki.net/wiki/NML:Deprecated_syntax

Rather than relying on ``var[0x41, 0, 0xFFFF]``, this PR adds a var ``town_index``

Town var 0x41 is a word, at least for OpenTTD purposes: https://newgrf-specs.tt-wiki.net/wiki/VariationalAction2/Towns

Tested with some FIRS code which is not helpful to other people as it has a bunch of unrelated changes, but the var works as expected.