### PR TITLE
Fix: Reject empty arrays of expressions

### DIFF
--- a/nml/actions/action2var.py
+++ b/nml/actions/action2var.py
@@ -631,6 +631,8 @@ class Varaction2Parser:
 
     def parse_expr(self, expr):
         if isinstance(expr, expression.Array):
+            if len(expr.values) == 0:
+                raise generic.ScriptError("An array of expressions cannot be empty", expr.pos)
             for expr2 in expr.values:
                 self.parse(expr2)
                 self.var_list.append(nmlop.VAL2)


### PR DESCRIPTION
@andythenorth found a bug ;)
```
switch(FEAT_INDUSTRIES, SELF, test_empty_expression_switch,
    // NML was throwing a not-descriptive parse error with an empty expression
    []) {
    return;
}
```
triggers "IndexError: pop from empty list" at https://github.com/OpenTTD/nml/blob/840613eb393eface5026dd15e491051176f6dc3c/nml/actions/action2var.py#L639.

But it really should have been rejected way earlier.