### PR TITLE
Fix: Use a most likely defined position when reporting error

### DIFF
--- a/nml/actions/action2var.py
+++ b/nml/actions/action2var.py
@@ -479,9 +479,9 @@ class Varaction2Parser:
         @type  expr: L{expression.Variable}
         """
         if not isinstance(expr.num, expression.ConstantNumeric):
-            raise generic.ScriptError("Variable number must be a constant number", expr.num.pos)
+            raise generic.ScriptError("Variable number must be a constant number", expr.pos)
         if not (expr.param is None or isinstance(expr.param, expression.ConstantNumeric)):
-            raise generic.ScriptError("Variable parameter must be a constant number", expr.param.pos)
+            raise generic.ScriptError("Variable parameter must be a constant number", expr.pos)
 
         if len(expr.extra_params) > 0:
             first_var = len(self.var_list) == 0


### PR DESCRIPTION
Errors without the corresponding line number are not very useful.

`action2var.parse_variable()` uses position of number or register when reporting an error, but they usually are not set. So it's better to use the position of the expression itself.