### PR TITLE
Fix: define PY_SSIZE_T_CLEAN in _lz77.c

### DIFF
--- a/nml/_lz77.c
+++ b/nml/_lz77.c
@@ -20,6 +20,7 @@
  * Loaded by lz77.py if available, to replace the universal python code if possible.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 /**


### PR DESCRIPTION
On newer versions of Python (3.10+) throw the following error:

  Error:    (SystemError) "PY_SSIZE_T_CLEAN macro must be defined for '#' formats".

This commit fixes this by defining the PY_SSIZE_T_CLEAN macro as
recommended in the [Python
docs](https://docs.python.org/3/c-api/arg.html#strings-and-buffers).

Signed-off-by: Felix Kaechele <felix@kaechele.ca>

First reported in Fedora here: https://bugzilla.redhat.com/show_bug.cgi?id=1987779