### PR TITLE
Change: add string pluralisation examples to example industry

### DIFF
--- a/examples/industry/example_industry.nml
+++ b/examples/industry/example_industry.nml
@@ -68,7 +68,18 @@ switch(FEAT_INDUSTRIES, SELF, factory_production_switch, [
 switch(FEAT_INDUSTRIES, SELF, extra_text_switch,
         // Put the production amount on the textstack for use in a string parameter.
         // See https://newgrf-specs.tt-wiki.net/wiki/NML:Language_files#String_parameters
-        [STORE_TEMP(this_month_production("GOOD"), 256)]) {
+        [
+            STORE_TEMP(
+                this_month_production("GOOD")
+                | 0 << 16, // shift 16 bits to store a second value in the same stack register
+                256
+            ),
+            STORE_TEMP(
+                1
+                | 2 << 16, // shift 16 bits to store a second value in the same stack register
+                257
+            )
+        ]) {
         return string(STR_INDUSTRY_EXTRA_TEXT);
 }
 

--- a/examples/industry/lang/english.lng
+++ b/examples/industry/lang/english.lng
@@ -1,5 +1,7 @@
 ##grflangid 0x01
+##plural 0
+
 STR_GRF_NAME                                                    :NML Example NewGRF: Industry
 STR_GRF_DESCRIPTION                                             :{ORANGE}NML Example NewGRF: Industry{}{BLACK}This NewGRF is intended to provide a coding example for the high-level NewGRF-coding language NML.
 
-STR_INDUSTRY_EXTRA_TEXT                                         :{}Goods produced this month: {YELLOW}{SIGNED_WORD}
+STR_INDUSTRY_EXTRA_TEXT                                         :{}Goods produced this month: {YELLOW}{SIGNED_WORD}{}{BLACK}Test pluralisation: {YELLOW}{SIGNED_WORD} unit{P 1 "" s}, {SIGNED_WORD} unit{P 2 "" s}, {SIGNED_WORD} unit{P 3 "" s}{}


### PR DESCRIPTION
May be useful, may not.  Documentation and test cases for string pluralisation is generally sparse at time of writing.