### PR TITLE
Add: Warn when ternary operator results are not read only

### DIFF
--- a/nml/actions/action2var.py
+++ b/nml/actions/action2var.py
@@ -418,6 +418,10 @@ class Varaction2Parser:
             self.var_list_size += 2 + diff_var.get_size()
             return expr.expr2
         else:
+            if not expr.is_read_only() and guard.is_read_only():
+                generic.print_warning(
+                    generic.Warning.GENERIC, "Ternary operator may have unexpected side effects", expr.pos
+                )
             guard_var = VarAction2StoreTempVar()
             guard_var.comment = "guard"
             inverted_guard_var = VarAction2StoreTempVar()


### PR DESCRIPTION
Closes #241

For `guard ? expr_true : expr_false`, first `guard` is evaluated, then stored as guard, and it's opposite stored as !guard. Then some magic happens for the result, it's translated as `!guard * expr_false + guard * expr_true`, meaning both expressions are evaluated in any case.

Warn if any of the expression is not read only is a small improvement but won't prevent side effects.

 The ideal solution would be to convert the ternary into a full action 2 in this case, but it's really not trivial to implement.