### PR TITLE
Fix: advanced spritelayout may use no buildings

### DIFF
--- a/nml/actions/action2layout.py
+++ b/nml/actions/action2layout.py
@@ -51,7 +51,7 @@ class Action2Layout(action2.Action2):
                 size += 10
             if advanced:
                 size += sprite.get_registers_size()
-        if len(self.sprite_list) == 0:
+        if len(self.sprite_list) == 0 and not advanced:
             size += 9
 
         regs = ["{} : register {:X}".format(reg.name, reg.register) for reg in self.param_registers]
@@ -65,7 +65,7 @@ class Action2Layout(action2.Action2):
             self.ground_sprite.write_flags(file)
             self.ground_sprite.write_registers(file)
         file.newline()
-        if len(self.sprite_list) == 0:
+        if len(self.sprite_list) == 0 and not advanced:
             file.print_dwordx(0)  # sprite number 0 == no sprite
             for _ in range(0, 5):
                 file.print_byte(0)  # empty bounding box. Note that number of zeros is 5, not 6


### PR DESCRIPTION
When testing stations, an issue was discovered for advanced sprite layouts.
If there's no buildingsprite, nmlc uses basic format "no building" output, but that's incorrect for advanced format.
As OpenTTD ignores this invalid data because it never supported basic format and just loops over `num-sprites` it was working fine (except for stations because prop 1A can define more than one layout, and invalid data is read in this case).
So nmlc had to be fixed with 2 options, rejecting no building for advanced sprite layouts, or allow no building and fix the output (requiring an update of the spec). 
We decided to update the spec to explicitely allow no building for advanced sprite layout as it was already supported by OpenTTD.

This PR implements the modified spec, and fixes the invalid output.