### PR TITLE
Update: [Actions] python versions for regression test

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-2016]
-        python-version: [3.5, 3.6, 3.7, 3.8, pypy3]
+        python-version: ['3.7', '3.8', '3.9', '3.10', pypy3]
         exclude:
           # Prebuilt pillow wheels aren't always available for the relevant PyPy version.
           # The Ubuntu runner has zlib headers and can build it locally, but these can't without more work.

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-2016]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', pypy3]
         exclude:
           # Prebuilt pillow wheels aren't always available for the relevant PyPy version.
           # The Ubuntu runner has zlib headers and can build it locally, but these can't without more work.
           - os: macOS-latest
             python-version: pypy3
-          - os: windows-2016
+          - os: windows-latest
             python-version: pypy3
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
 
   release-windows:
     name: Windows release
-    runs-on: windows-2016
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-2016]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`macos-latest` image is now `macos-11` and doesn't have python 3.5 nor 3.6.
And on January 24th, python 3.5 will be removed from all images.
So I think it's safe to just remove 3.5 and 3.6, and also add 3.9 and 3.10 in the checks.

Also update workflows to use `windows-latest` image as `windows-2016` is deprecated