### PR TITLE
Codechange: black changed code style for power operators

### DIFF
--- a/nml/expression/base_expression.py
+++ b/nml/expression/base_expression.py
@@ -147,7 +147,7 @@ class ConstantNumeric(Expression):
         self.value = generic.truncate_int32(value)
         self.uvalue = self.value
         if self.uvalue < 0:
-            self.uvalue += 2 ** 32
+            self.uvalue += 2**32
 
     def debug_print(self, indentation):
         generic.print_dbg(indentation, "Int:", self.value)


### PR DESCRIPTION
Black 22.1.0 now removes spaces around power operators if both operands are simple.