### PR TITLE
Fix #253: Use non-ternary varaction2 sequence for abs() builtin function

### DIFF
--- a/nml/actions/actionD.py
+++ b/nml/actions/actionD.py
@@ -192,6 +192,18 @@ def parse_ternary_op(assignment):
     return actions
 
 
+def parse_abs_op(assignment):
+    assert isinstance(assignment.value, expression.AbsOp)
+    actions = parse_actionD(ParameterAssignment(assignment.param, assignment.value.expr))
+    cond_block = conditional.Conditional(
+        nmlop.CMP_LT(assignment.value.expr, 0),
+        [ParameterAssignment(assignment.param, nmlop.SUB(0, assignment.value.expr))],
+        None,
+    )
+    actions.extend(conditional.ConditionalList([cond_block]).get_action_list())
+    return actions
+
+
 def parse_special_check(assignment):
     check = assignment.value
     assert isinstance(check, expression.SpecialCheck)
@@ -367,6 +379,9 @@ def parse_actionD(assignment):
 
     if isinstance(assignment.value, expression.TernaryOp):
         return parse_ternary_op(assignment)
+
+    if isinstance(assignment.value, expression.AbsOp):
+        return parse_abs_op(assignment)
 
     if isinstance(assignment.value, expression.SpecialCheck):
         return parse_special_check(assignment)

--- a/nml/expression/__init__.py
+++ b/nml/expression/__init__.py
@@ -33,6 +33,7 @@ from .storage_op import StorageOp
 from .string import String
 from .string_literal import StringLiteral
 from .ternaryop import TernaryOp
+from .abs_op import AbsOp
 from .variable import Variable
 
 is_valid_id = re.compile("[a-zA-Z_][a-zA-Z0-9_]{3}$")

--- a/nml/expression/abs_op.py
+++ b/nml/expression/abs_op.py
@@ -1,0 +1,54 @@
+__license__ = """
+NML is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+NML is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with NML; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
+
+from nml import generic
+
+from .base_expression import ConstantNumeric, Expression, Type
+
+
+class AbsOp(Expression):
+    def __init__(self, expr, pos):
+        Expression.__init__(self, pos)
+        self.expr = expr
+
+    def debug_print(self, indentation):
+        generic.print_dbg(indentation, "abs():")
+        self.expr.debug_print(indentation + 2)
+
+    def reduce(self, id_dicts=None, unknown_id_fatal=True):
+        expr = self.expr.reduce(id_dicts)
+        if expr.type() != Type.INTEGER:
+            raise generic.ScriptError("abs() requires an integer argument.", expr.pos)
+        if isinstance(expr, ConstantNumeric):
+            if expr.value < 0:
+                return ConstantNumeric(-expr.value)
+            else:
+                return ConstantNumeric(expr.value)
+        return AbsOp(expr, self.pos)
+
+    def supported_by_action2(self, raise_error):
+        return self.expr.supported_by_action2(raise_error)
+
+    def supported_by_actionD(self, raise_error):
+        return self.expr.supported_by_actionD(raise_error)
+
+    def collect_references(self):
+        return self.expr.collect_references()
+
+    def is_read_only(self):
+        return self.expr.is_read_only()
+
+    def __str__(self):
+        return "abs(" + str(self.expr) + ")"

--- a/nml/expression/functioncall.py
+++ b/nml/expression/functioncall.py
@@ -27,7 +27,7 @@ from .cargo import AcceptCargo, ProduceCargo
 from .parameter import parse_string_to_dword
 from .storage_op import StorageOp
 from .string_literal import StringLiteral
-from .ternaryop import TernaryOp
+from .abs_op import AbsOp
 
 
 class FunctionCall(Expression):
@@ -577,8 +577,7 @@ def builtin_int(name, args, pos):
 def builtin_abs(name, args, pos):
     if len(args) != 1:
         raise generic.ScriptError(name + "() must have 1 parameter", pos)
-    guard = nmlop.CMP_LT(args[0], 0)
-    return TernaryOp(guard, nmlop.SUB(0, args[0]), args[0], args[0].pos).reduce()
+    return AbsOp(args[0], args[0].pos).reduce()
 
 
 @builtin


### PR DESCRIPTION
This avoids the function argument being replicated in the output and being executed at run-time three times.