### PR TITLE
Codechange: improve error reporting for procedure calls missing '()'

### DIFF
--- a/nml/expression/abs_op.py
+++ b/nml/expression/abs_op.py
@@ -30,6 +30,8 @@ class AbsOp(Expression):
     def reduce(self, id_dicts=None, unknown_id_fatal=True):
         expr = self.expr.reduce(id_dicts)
         if expr.type() != Type.INTEGER:
+            if expr.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(expr.name, expr.pos)
             raise generic.ScriptError("abs() requires an integer argument.", expr.pos)
         if isinstance(expr, ConstantNumeric):
             if expr.value < 0:

--- a/nml/expression/bin_not.py
+++ b/nml/expression/bin_not.py
@@ -32,6 +32,8 @@ class BinNot(Expression):
     def reduce(self, id_dicts=None, unknown_id_fatal=True):
         expr = self.expr.reduce(id_dicts)
         if expr.type() != Type.INTEGER:
+            if expr.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(expr.name, expr.pos)
             raise generic.ScriptError("Not-operator (~) requires an integer argument.", expr.pos)
         if isinstance(expr, ConstantNumeric):
             return ConstantNumeric(0xFFFFFFFF ^ expr.value)
@@ -67,6 +69,8 @@ class Not(Expression):
     def reduce(self, id_dicts=None, unknown_id_fatal=True):
         expr = self.expr.reduce(id_dicts)
         if expr.type() != Type.INTEGER:
+            if expr.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(expr.name, expr.pos)
             raise generic.ScriptError("Not-operator (!) requires an integer argument.", expr.pos)
         if isinstance(expr, ConstantNumeric):
             return ConstantNumeric(expr.value == 0)

--- a/nml/expression/bitmask.py
+++ b/nml/expression/bitmask.py
@@ -33,6 +33,8 @@ class BitMask(Expression):
         for orig_expr in self.values:
             val = orig_expr.reduce(id_dicts)
             if val.type() != Type.INTEGER:
+                if val.type() == Type.SPRITEGROUP_REF:
+                    raise generic.ProcCallSyntaxError(val.name, val.pos)
                 raise generic.ScriptError("Parameters of 'bitmask' must be integers.", orig_expr.pos)
             if isinstance(val, ConstantNumeric) and val.value >= 32:
                 raise generic.ScriptError("Parameters of 'bitmask' cannot be greater than 31", orig_expr.pos)

--- a/nml/expression/boolean.py
+++ b/nml/expression/boolean.py
@@ -37,7 +37,9 @@ class Boolean(Expression):
     def reduce(self, id_dicts=None, unknown_id_fatal=True):
         expr = self.expr.reduce(id_dicts)
         if expr.type() != Type.INTEGER:
-            raise generic.ScriptError("Only integers can be converted to a boolean value.", self.pos)
+            if expr.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(expr.name, expr.pos)
+            raise generic.ScriptError("Only integers can be converted to a boolean value.", expr.pos)
         if expr.is_boolean():
             return expr
         return Boolean(expr)

--- a/nml/expression/storage_op.py
+++ b/nml/expression/storage_op.py
@@ -103,11 +103,15 @@ class StorageOp(Expression):
         if self.value is not None:
             value = self.value.reduce(id_dicts)
             if value.type() != Type.INTEGER:
+                if value.type() == Type.SPRITEGROUP_REF:
+                    raise generic.ProcCallSyntaxError(value.name, value.pos)
                 raise generic.ScriptError("Value to store must be an integer.", value.pos)
             args.append(value)
 
         register = self.register.reduce(id_dicts)
         if register.type() != Type.INTEGER:
+            if register.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(register.name, register.pos)
             raise generic.ScriptError("Register to access must be an integer.", register.pos)
         if isinstance(register, ConstantNumeric) and register.value > self.info["max"]:
             raise generic.ScriptError("Maximum register for {} is {:d}".format(self.name, self.info["max"]), self.pos)

--- a/nml/expression/ternaryop.py
+++ b/nml/expression/ternaryop.py
@@ -44,6 +44,12 @@ class TernaryOp(Expression):
             else:
                 return expr2
         if guard.type() != Type.INTEGER or expr1.type() != Type.INTEGER or expr2.type() != Type.INTEGER:
+            if guard.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(guard.name, guard.pos)
+            if expr1.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(expr1.name, expr1.pos)
+            if expr2.type() == Type.SPRITEGROUP_REF:
+                raise generic.ProcCallSyntaxError(expr2.name, expr2.pos)
             raise generic.ScriptError("All parts of the ternary operator (?:) must be integers.", self.pos)
         return TernaryOp(guard, expr1, expr2, self.pos)
 

--- a/nml/generic.py
+++ b/nml/generic.py
@@ -252,6 +252,11 @@ class RangeError(ScriptError):
         )
 
 
+class ProcCallSyntaxError(ScriptError):
+    def __init__(self, name, pos=None):
+        ScriptError.__init__(self, "Missing '()' after '{}'.".format(name), pos)
+
+
 class ImageError(ScriptError):
     def __init__(self, value, filename, pos=None):
         ScriptError.__init__(self, value, ImageFilePosition(filename, pos))

--- a/nml/nmlop.py
+++ b/nml/nmlop.py
@@ -120,11 +120,19 @@ def unsigned_rrotate(a, b):
 
 def validate_func_int(expr1, expr2, pos):
     if expr1.type() != Type.INTEGER or expr2.type() != Type.INTEGER:
+        if expr1.type() == Type.SPRITEGROUP_REF:
+            raise generic.ProcCallSyntaxError(expr1.name, expr1.pos)
+        if expr2.type() == Type.SPRITEGROUP_REF:
+            raise generic.ProcCallSyntaxError(expr2.name, expr2.pos)
         raise generic.ScriptError("Binary operator requires both operands to be integers.", pos)
 
 
 def validate_func_float(expr1, expr2, pos):
     if expr1.type() not in (Type.INTEGER, Type.FLOAT) or expr2.type() not in (Type.INTEGER, Type.FLOAT):
+        if expr1.type() == Type.SPRITEGROUP_REF:
+            raise generic.ProcCallSyntaxError(expr1.name, expr1.pos)
+        if expr2.type() == Type.SPRITEGROUP_REF:
+            raise generic.ProcCallSyntaxError(expr2.name, expr2.pos)
         raise generic.ScriptError("Binary operator requires both operands to be integers or floats.", pos)
     # If one is a float, the other must be constant since we can't handle floats at runtime
     if (expr1.type() == Type.FLOAT and not isinstance(expr2, (ConstantNumeric, ConstantFloat))) or (


### PR DESCRIPTION
Error messages like `Binary operator requires both operands to be integers or floats.` are not very understandable for users when the error is simply a missing `()`.

Added special handling for these errors so users will get a more useful `Missing '()' after '<procedure_name>'.` message.

I think I found all possible occurrences.