### PR TITLE
Fix: [Actions] release workflow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        twine upload --username __token__ wheelhouse/*-manylinux*.whl
+        twine upload --username __token__ dist/*-manylinux*.whl
 
 
   release-osx:


### PR DESCRIPTION
Bumping versions in workflows changed the path where manylinux puts generated wheels.