### PR TITLE
More issues in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         twine upload --username __token__ dist/*.whl dist/*.tar.gz
         version=`python setup.py --version`
         archive=`echo "nml-$version.tar.gz"`
-        echo "::set-output name=archive::$archive"
+        echo "archive=$archive" >> $GITHUB_OUTPUT
       id: nml_source_archive
 
     - name: Publish source tarball
@@ -137,7 +137,7 @@ jobs:
         $version = python setup.py --version
         $archive = echo "nml-standalone-$version-win64.zip"
         Compress-Archive -Path dist/nmlc.exe, LICENSE, README.md, docs/changelog.txt -DestinationPath $archive
-        echo "::set-output name=archive::$archive"
+        echo "archive=$archive" >> $GITHUB_OUTPUT
       id: nml_archive
 
     - name: Publish standalone executable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
       uses: RalfG/python-wheels-manylinux-build@v0.6.0-manylinux2014_x86_64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
-        build-requirements: '-e .'  # pip args
+        build-requirements: '-e . --verbose'  # pip args
+        pre-build-command: 'git config --global --add safe.directory ${GITHUB_WORKSPACE}'
 
     - name: Publish manylinux Python wheels
       env:


### PR DESCRIPTION
Adding `--verbose` to pip command helped to find the manylinux issue, keeping it will not hurt :)
Manylinux issue was
 ```
  fatal: detected dubious ownership in repository at '/github/workspace'
  To add an exception for this directory, call:

  	git config --global --add safe.directory /github/workspace
  fatal: detected dubious ownership in repository at '/github/workspace'
  To add an exception for this directory, call:

  	git config --global --add safe.directory /github/workspace
  Git checkout found but cannot determine its version. Error:  Command '['git', '-C', '/github/workspace', 'diff-index', 'HEAD']' returned non-zero exit status 128.
```
So no surprised it decided to use 0.0.0 as version.

While fixing stuff `set-output` is deprecated.
Will also need to replace `actions/upload-release-asset` as it's not maintained and uses deprecated node.js (but no hurry with our not so frequent releases)