### PR TITLE
Feature: support for variant_group action 0 prop for vehicles

### DIFF
--- a/nml/actions/action0properties.py
+++ b/nml/actions/action0properties.py
@@ -447,6 +447,7 @@ properties[0x00] = {
     ],
     "curve_speed_mod":                {"size": 2, "num": 0x2E, "unit_conversion": 256},
     "variant_group":                  {"size": 2, "num": 0x2F},
+    "extra_flags":                    {"size": 4, "num": 0x30},
 }
 # fmt: on
 
@@ -524,6 +525,7 @@ properties[0x01] = {
         zero_refit_mask(0x16),
     ],
     "variant_group":                {"size": 2, "num": 0x26},
+    "extra_flags":                  {"size": 4, "num": 0x27},
 }
 # fmt: on
 
@@ -592,6 +594,7 @@ properties[0x02] = {
         zero_refit_mask(0x11),
     ],
     "variant_group":                {"size": 2, "num": 0x20},
+    "extra_flags":                  {"size": 4, "num": 0x21},
 }
 # fmt: on
 
@@ -652,6 +655,7 @@ properties[0x03] = {
     ],
     "range":                        {"size": 2, "num": 0x1F},
     "variant_group":                {"size": 2, "num": 0x20},
+    "extra_flags":                  {"size": 4, "num": 0x21},
 }
 # fmt: on
 

--- a/nml/actions/action0properties.py
+++ b/nml/actions/action0properties.py
@@ -446,6 +446,7 @@ properties[0x00] = {
         , zero_refit_mask(0x1D)
     ],
     "curve_speed_mod":                {"size": 2, "num": 0x2E, "unit_conversion": 256},
+    "variant_group":                  {"size": 2, "num": 0x2F},
 }
 # fmt: on
 
@@ -522,6 +523,7 @@ properties[0x01] = {
         {"custom_function": lambda value: ctt_list(0x25, value)},
         zero_refit_mask(0x16),
     ],
+    "variant_group":                {"size": 2, "num": 0x26},
 }
 # fmt: on
 
@@ -589,6 +591,7 @@ properties[0x02] = {
         {"custom_function": lambda value: ctt_list(0x1F, value)},
         zero_refit_mask(0x11),
     ],
+    "variant_group":                {"size": 2, "num": 0x20},
 }
 # fmt: on
 
@@ -648,6 +651,7 @@ properties[0x03] = {
         zero_refit_mask(0x13),
     ],
     "range":                        {"size": 2, "num": 0x1F},
+    "variant_group":                {"size": 2, "num": 0x20},
 }
 # fmt: on
 

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -130,7 +130,7 @@ constant_numbers = {
     "SHIP_FLAG_NO_BREAKDOWN_SMOKE": 6,
     "SHIP_FLAG_SPRITE_STACK": 7,
 
-    # aircrafts misc flags
+    # aircraft misc flags
     "AIRCRAFT_FLAG_2CC"  : 1,
     "AIRCRAFT_FLAG_AUTOREFIT": 4,
     "AIRCRAFT_FLAG_NO_BREAKDOWN_SMOKE": 6,
@@ -140,6 +140,12 @@ constant_numbers = {
     "VEHICLE_FLAG_2CC" : 1,
     "VEHICLE_FLAG_AUTOREFIT": 4,
     "VEHICLE_FLAG_NO_BREAKDOWN_SMOKE": 6,
+
+    # vehicle extra flags
+    "VEHICLE_FLAG_DISABLE_NEW_VEHICLE_MESSAGE"    : 0,
+    "VEHICLE_FLAG_DISABLE_EXCLUSIVE_PREVIEW"      : 1,
+    "VEHICLE_FLAG_SYNC_VARIANT_EXCLUSIVE_PREVIEW" : 2,
+    "VEHICLE_FLAG_SYNC_VARIANT_RELIABILITY"       : 3,
 
     # Graphic flags for waterfeatures
     "WATERFEATURE_ALTERNATIVE_SPRITES" : 0,


### PR DESCRIPTION
This is draft, the patch is simple, but I'm not convinced `variant_group` is the best name for the action 0 prop.

Supports Peter's addition of vehicle variants in client.