### PR TITLE
Fix: By default there is no ELRL railtype.

### DIFF
--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -1354,8 +1354,8 @@ def create_spritegroup_ref(name, info, pos):
 cargo_numbers = {}
 
 is_default_railtype_table = True
-# if no railtype_table is provided, OpenTTD assumes these 4 railtypes
-railtype_table = {"RAIL": 0, "ELRL": 1, "MONO": 1, "MGLV": 2}
+# if no railtype_table is provided, OpenTTD assumes these 3 railtypes
+railtype_table = {"RAIL": 0, "MONO": 1, "MGLV": 2}
 
 is_default_roadtype_table = True
 # if no roadtype_table is provided, OpenTTD sets all vehicles to ROAD


### PR DESCRIPTION
To define ELRL trains, you can either
* define a railtype table containing ELRL, or
* use track_type=RAIL with engine_class=ENGINE_CLASS_ELECTRIC.

This was already reflected in the documentation.

In no case does ELRL match MONO.