### PR TITLE
Add: STAT_ALL_TILES constant for use instead of 0xFF 

### DIFF
--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -373,6 +373,9 @@ constant_numbers = {
     "STAT_FLAG_CUSTOM_FOUNDATIONS"    : 3,
     "STAT_FLAG_EXTENDED_FOUNDATIONS"  : 4,
 
+    # station tiles
+    "STAT_ALL_TILES"     : 0xFF,
+
     # station animation triggers
     "STAT_ANIM_IS_BUILT"              : 0,
     "STAT_ANIM_CARGO_ARRIVES"         : 1,


### PR DESCRIPTION
Would be used instead of 0xFF with properties: draw_pylon_tiles, hide_wire_tiles and non_traversable_tiles.