### PR TITLE
Codechange: [Actions] Use 'gh' to upload release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,23 +79,11 @@ jobs:
     - name: Build and publish wheel and source distribution
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload --username __token__ dist/*.whl dist/*.tar.gz
-        version=`python setup.py --version`
-        archive=`echo "nml-$version.tar.gz"`
-        echo "archive=$archive" >> $GITHUB_OUTPUT
-      id: nml_source_archive
-
-    - name: Publish source tarball
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./dist/${{ steps.nml_source_archive.outputs.archive }}
-        asset_name: ${{ steps.nml_source_archive.outputs.archive }}
-        asset_content_type: application/gzip
+        gh release upload ${{ github.event.release.tag_name }} dist/*.tar.gz
 
   release-windows:
     name: Windows release
@@ -131,21 +119,11 @@ jobs:
         python setup.py bdist_wheel
         twine upload --username __token__ dist/*.whl
 
-    - name: Build standalone executable
-      run: |
-        pyinstaller nmlc.spec
-        $version = python setup.py --version
-        $archive = echo "nml-standalone-$version-win64.zip"
-        Compress-Archive -Path dist/nmlc.exe, LICENSE, README.md, docs/changelog.txt -DestinationPath $archive
-        echo "archive=$archive" >> $GITHUB_OUTPUT
-      id: nml_archive
-
-    - name: Publish standalone executable
-      uses: actions/upload-release-asset@v1
+    - name: Build and publish standalone executable
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./${{ steps.nml_archive.outputs.archive }}
-        asset_name: ${{ steps.nml_archive.outputs.archive }}
-        asset_content_type: application/zip
+      run: |
+        pyinstaller nmlc.spec
+        $archive = "nml-standalone-${{ github.event.release.tag_name }}-win64.zip"
+        Compress-Archive -Path dist/nmlc.exe, LICENSE, README.md, docs/changelog.txt -DestinationPath $archive
+        gh release upload ${{ github.event.release.tag_name }} $archive


### PR DESCRIPTION
Release workflow needed some work (again).
Removed actions/upload-release-asset as it's very outdated.
Use GitHub CLI to upload the assets.

I tested it on https://github.com/glx22/nml/releases/tag/0.7.2 ([workflow run](https://github.com/glx22/nml/actions/runs/4726187062) with wheels publishing disabled)