### PR TITLE
Fix: [Actions] nmlc version could not be determined during regression

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,6 +26,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: Checkout tags
+      uses: openttd/actions/checkout@v2
+      with:
+        with-tags: true
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
Regression log is very noisy with each test triggering
```
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
Git checkout found but cannot determine its version. Error:  Command '['git', '-C', '/Users/runner/work/nml/nml', 'describe', '--tags', '--long']' returned non-zero exit status 128.
Git checkout found but cannot determine its version. Error:  Command '['git', '-C', '/Users/runner/work/nml/nml', 'describe', '--tags', '--long']' returned non-zero exit status 128.
```

Fetch more data during checkout so `git describe` can do its job.