### PR TITLE
Add: --no-32bpp and --no-extra-zoom option to skip some alternative sprites

### DIFF
--- a/nml/ast/alt_sprites.py
+++ b/nml/ast/alt_sprites.py
@@ -30,8 +30,10 @@ zoom_levels = {
     "ZOOM_LEVEL_OUT_4X": 4,
     "ZOOM_LEVEL_OUT_8X": 5,
 }
+allow_extra_zoom = True
 
 bit_depths = {"BIT_DEPTH_8BPP": 8, "BIT_DEPTH_32BPP": 32.0}
+allow_32bpp = True
 
 
 class AltSpritesBlock(base_statement.BaseStatement):
@@ -86,7 +88,7 @@ class AltSpritesBlock(base_statement.BaseStatement):
             )
         global any_32bpp_sprites
         if self.bit_depth == 32:
-            any_32bpp_sprites = True
+            any_32bpp_sprites = allow_32bpp
 
         if len(param_list) >= 4:
             self.image_file = param_list[3].reduce()
@@ -111,6 +113,8 @@ class AltSpritesBlock(base_statement.BaseStatement):
         self.sprite_list = sprite_list
 
     def pre_process(self):
+        if (self.bit_depth == 32 and not allow_32bpp) or (self.zoom_level != 0 and not allow_extra_zoom):
+            return
         block = sprite_container.SpriteContainer.resolve_sprite_block(self.name)
         block.add_sprite_data(
             self.sprite_list, self.image_file, self.pos, self.zoom_level, self.bit_depth, self.mask_file

--- a/nml/main.py
+++ b/nml/main.py
@@ -87,6 +87,8 @@ def parse_cli(argv):
         verbosity=generic.verbosity_level,
         rebuild_parser=False,
         debug_parser=False,
+        allow_extra_zoom=True,
+        allow_32bpp=True,
     )
     opt_parser.add_option("-d", "--debug", action="store_true", dest="debug", help="write the AST to stdout")
     opt_parser.add_option("-s", "--stack", action="store_true", dest="stack", help="Dump stack when an error occurs")
@@ -218,6 +220,10 @@ def parse_cli(argv):
         const=generic.Warning.DEPRECATION,
         help="Disable deprecation warnings",
     )
+    opt_parser.add_option(
+        "--no-extra-zoom", action="store_false", dest="allow_extra_zoom", help="Skip extra zoom alternative sprites"
+    )
+    opt_parser.add_option("--no-32bpp", action="store_false", dest="allow_32bpp", help="Skip 32bpp alternative sprites")
 
     opts, args = opt_parser.parse_args(argv)
 
@@ -225,6 +231,8 @@ def parse_cli(argv):
     generic.Warning.disabled = opts.disable_warning
     generic.set_cache_root_dir(None if opts.no_cache else opts.cache_dir)
     spritecache.keep_orphaned = opts.keep_orphaned
+    alt_sprites.allow_extra_zoom = opts.allow_extra_zoom
+    alt_sprites.allow_32bpp = opts.allow_32bpp
 
     opts.outputfile_given = (
         opts.grf_filename or opts.nfo_filename or opts.nml_filename or opts.dep_filename or opts.outputs


### PR DESCRIPTION
Following a discord conversation.
* zephyris
Hey, nmlc question for you all. Is there an argument which makes it ignore alternate zoom sprites? Similarly, make it ignore 32bpp alternates of sprites?
* zephyris
I'm hoping to make multiple versions of a grf at build time - file sizes get pretty enormous when including 32bpp and not everyone will need/want that.
* glx
I think it should be possible to add nozoom and no32bpp flags to nmlc

And it is indeed possible :)