### PR TITLE
Change: Extend vehicle random bits to 16.

### DIFF
--- a/nml/actions/action2random.py
+++ b/nml/actions/action2random.py
@@ -62,13 +62,13 @@ class RandomAction2Choice:
 
 
 vehicle_random_types = {
-    "SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 8, "triggers": True},
-    "PARENT": {"type": 0x83, "param": 0, "first_bit": 0, "num_bits": 8, "triggers": False},
-    "TILE": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 8, "triggers": False},
-    "BACKWARD_SELF": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 8, "triggers": False, "value": 0x00},
-    "FORWARD_SELF": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 8, "triggers": False, "value": 0x40},
-    "BACKWARD_ENGINE": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 8, "triggers": False, "value": 0x80},
-    "BACKWARD_SAMEID": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 8, "triggers": False, "value": 0xC0},
+    "SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 16, "triggers": True},
+    "PARENT": {"type": 0x83, "param": 0, "first_bit": 0, "num_bits": 16, "triggers": False},
+    "TILE": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 16, "triggers": False},
+    "BACKWARD_SELF": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 16, "triggers": False, "value": 0x00},
+    "FORWARD_SELF": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 16, "triggers": False, "value": 0x40},
+    "BACKWARD_ENGINE": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 16, "triggers": False, "value": 0x80},
+    "BACKWARD_SAMEID": {"type": 0x84, "param": 1, "first_bit": 0, "num_bits": 16, "triggers": False, "value": 0xC0},
 }
 random_types = {
     0x00: vehicle_random_types,

--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -147,7 +147,7 @@ varact2vars_vehicles = {
     'position_in_articulated_veh'          : {'var': 0x4D, 'start':  0, 'size':  8},
     'position_in_articulated_veh_from_end' : {'var': 0x4D, 'start':  8, 'size':  8},
     'waiting_triggers'                 : {'var': 0x5F, 'start':  0, 'size':  8},
-    'random_bits'                      : {'var': 0x5F, 'start':  8, 'size':  8},
+    'random_bits'                      : {'var': 0x5F, 'start':  8, 'size': 16},
     'direction'                        : {'var': 0x9F, 'start':  0, 'size':  8},
     'vehicle_is_hidden'                : {'var': 0xB2, 'start':  0, 'size':  1},
     'vehicle_is_stopped'               : {'var': 0xB2, 'start':  1, 'size':  1},


### PR DESCRIPTION
The top 8 bits will always be zero if the game does not support 16 bit vehicle. random data.

OpenTTD#10701 increased vehicle random bits from 8 to 16. This change does the NML side.

Not tested.