### PR TITLE
Fix dfb4499: incomplete read only checks (again)

### DIFF
--- a/nml/ast/switch.py
+++ b/nml/ast/switch.py
@@ -416,6 +416,12 @@ class RandomSwitch(switch_base_class):
             all_refs += choice.result.value.collect_references()
         return all_refs
 
+    def is_read_only(self):
+        for choice in self.choices:
+            if not choice.result.value.is_read_only():
+                return False
+        return True
+
     def debug_print(self, indentation):
         generic.print_dbg(indentation, "Random")
         generic.print_dbg(indentation + 2, "Feature:", next(iter(self.feature_set)))


### PR DESCRIPTION
From a stacktrace reported on discord:
```
Preprocessing ...Traceback (most recent call last):
  File "nmlc", line 6, in <module>
  File "nml\main.py", line 623, in run
  File "nml\main.py", line 339, in main
  File "nml\main.py", line 439, in nml
  File "nml\ast\base_statement.py", line 155, in pre_process
  File "nml\ast\item.py", line 99, in pre_process
  File "nml\ast\base_statement.py", line 155, in pre_process
  File "nml\ast\item.py", line 236, in pre_process
  File "nml\ast\item.py", line 295, in reduce_expressions
  File "nml\actions\action2var.py", line 1156, in reduce_varaction2_expr
  File "nml\expression\identifier.py", line 74, in reduce
  File "nml\expression\spritegroup_ref.py", line 85, in reduce
  File "nml\ast\switch.py", line 96, in optimise
  File "nml\expression\spritegroup_ref.py", line 98, in is_read_only
  File "nml\ast\switch.py", line 133, in is_read_only
  File "nml\expression\spritegroup_ref.py", line 98, in is_read_only
  File "nml\ast\switch.py", line 133, in is_read_only
  File "nml\expression\spritegroup_ref.py", line 98, in is_read_only
AttributeError: 'RandomSwitch' object has no attribute 'is_read_only'
```

Random switches can be used in switch expression, and need to implement `is_read_only`.