### PR TITLE
Change: Use a single replacenew-type 'SIGNALS' instead of 3 different constants.

### DIFF
--- a/nml/actions/action5.py
+++ b/nml/actions/action5.py
@@ -55,9 +55,10 @@ class Action5BlockType:
 
 
 action5_table = {
-    "PRE_SIGNAL": (0x04, 48, Action5BlockType.FIXED),
-    "PRE_SIGNAL_SEMAPHORE": (0x04, 112, Action5BlockType.FIXED),
-    "PRE_SIGNAL_SEMAPHORE_PBS": (0x04, 240, Action5BlockType.OFFSET),
+    "PRE_SIGNAL": (0x04, 48, Action5BlockType.OFFSET),  # deprecated, use "SIGNALS" in all cases
+    "PRE_SIGNAL_SEMAPHORE": (0x04, 112, Action5BlockType.OFFSET),  # deprecated, use "SIGNALS" in all cases
+    "PRE_SIGNAL_SEMAPHORE_PBS": (0x04, 240, Action5BlockType.OFFSET),  # deprecated, use "SIGNALS" in all cases
+    "SIGNALS": (0x04, 240, Action5BlockType.OFFSET),
     "CATENARY": (0x05, 48, Action5BlockType.OFFSET),
     "FOUNDATIONS_SLOPES": (0x06, 74, Action5BlockType.FIXED),
     "FOUNDATIONS_SLOPES_HALFTILES": (0x06, 90, Action5BlockType.OFFSET),


### PR DESCRIPTION
# Motivation
Fixes #290.

Currently there are 3 `replacenew`-types to replace signal graphics:
* `PRE_SIGNAL`
* `PRE_SIGNAL_SEMAPHORE`
* `PRE_SIGNAL_SEMAPHORE_PBS`

They all create the same code.

# Description
Add a new type `SIGNALS`, not to be confused with the existing `NEW_SIGNALS`.
The 3 old types will be deprecated and removed from the documentation.
