### PR TITLE
Add: Support for build probability action CB 162 var10 0 (reverse rail vehicle)

### DIFF
--- a/nml/actions/action3_callbacks.py
+++ b/nml/actions/action3_callbacks.py
@@ -71,6 +71,7 @@ callbacks[0x00] = {
     'cargo_age_period'                     : {'type': 'cb', 'num': 0x36, 'var10': 0x2B},
     'curve_speed_mod'                      : {'type': 'cb', 'num': 0x36, 'var10': 0x2E},
     'create_effect'                        : {'type': 'cb', 'num': 0x160},
+    'reverse_build_probability'            : {'type': 'cb', 'num': 0x162, 'var10': 0x00},
 }
 callbacks[0x00].update(general_vehicle_cbs)
 


### PR DESCRIPTION
Implement support for OpenTTD's "vehicle build probability" callback 162.

This was intended to be a generic probability action, with the action provided in var 10. This is handled by nmlc.

The callback is implemented as 'reverse_build_probability`.