### PR TITLE
Add: Support town_production_effect and town_production_multiplier.

### DIFF
--- a/nml/actions/action0properties.py
+++ b/nml/actions/action0properties.py
@@ -1263,6 +1263,8 @@ properties[0x0B] = {
     "units_of_cargo":            {"num": 0x1B, "size": 2, "string": 0xDC},
     "items_of_cargo":            {"num": 0x1C, "size": 2, "string": 0xDC},
     "capacity_multiplier":       {"num": 0x1D, "size": 2, "unit_conversion": 0x100},
+    "town_production_effect":    {"num": 0x1E, "size": 1},
+    "town_production_multiplier": {"num": 0x1F, "size": 2, "unit_conversion": 0x100},
 }
 # fmt: on
 

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -907,6 +907,11 @@ constant_numbers = {
     "TOWNGROWTH_FOOD"                       : 0x0B,
     "TOWNGROWTH_NONE"                       : 0xFF,
 
+    # Town production effect on cargo
+    "TOWNPRODUCTION_PASSENGERS"             : 0x00,
+    "TOWNPRODUCTION_MAIL"                   : 0x02,
+    "TOWNPRODUCTION_NONE"                   : 0xFF,
+
     # Cargo callbacks
     "CARGO_CB_PROFIT"                       : 0x01,
     "CARGO_CB_STATION_RATING"               : 0x02,


### PR DESCRIPTION
Provides support for town production effect and multiplier properties of OpenTTD#11947

```
        town_production_effect:     TOWNPRODUCTION_PASSENGERS;
        town_production_multiplier: 1.0;
```

```
        town_production_effect:     TOWNPRODUCTION_MAIL;
        town_production_multiplier: 0.75;
```