### PR TITLE
Fix: Include information about relevant block in ScriptError message

### DIFF
--- a/nml/expression/base_expression.py
+++ b/nml/expression/base_expression.py
@@ -92,7 +92,7 @@ class Expression:
         @return: True if this expression can be calculated by advanced varaction2.
         """
         if raise_error:
-            raise generic.ScriptError("This expression is not supported in a switch-block", self.pos)
+            raise generic.ScriptError("This expression is not supported in a switch-block or produce-block", self.pos)
         return False
 
     def supported_by_actionD(self, raise_error):


### PR DESCRIPTION
Fixes #238, which refers to the error message in Action2 parser not containing `produce-block` as a relevant block.

This is my first commit to this repository, I hope someone will guide me in case anything is not correctly presented.