### PR TITLE
Change: Remove road stops variable random_bits

### DIFF
--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -808,7 +808,6 @@ varact2vars_roadstop = {
     'animation_frame'       : {'var': 0x49, 'start':  0, 'size':  8},
 
     'waiting_triggers'      : {'var': 0x5F, 'start':  0, 'size':  8},
-    'random_bits'           : {'var': 0x5F, 'start':  8, 'size': 24},
     'random_bits_tile'      : {'var': 0x5F, 'start': 24, 'size':  8},
 }
 


### PR DESCRIPTION
This was a joint variable for random_bits_tile and random_bits_station, it is not required, and not in the list of documented variables.