### PR TITLE
Update: Python versions for regression

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -15,14 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy3.7']
+        python-version: ['3.9', '3.10', '3.11', '3.12', 'pypy3.9']
         exclude:
           # Prebuilt pillow wheels aren't always available for the relevant PyPy version.
           # The Ubuntu runner has zlib headers and can build it locally, but these can't without more work.
           - os: macOS-latest
-            python-version: pypy3.7
+            python-version: pypy3.9
           - os: windows-latest
-            python-version: pypy3.7
+            python-version: pypy3.9
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
`macos-latest` doesn't have python 3.7 or 3.8 (though regression in PRs fails only for missing 3.7).
Test with more recent python version for all targets.