### PR TITLE
Fix #340: Always use raw strings for token regex

### DIFF
--- a/nml/tokens.py
+++ b/nml/tokens.py
@@ -195,7 +195,7 @@ class NMLLexer:
         self.increment_lines(t.value.count("\n"))
 
     def t_ignore_whitespace(self, t):
-        "[ \t\r]+"
+        r"[ \t\r]+"
         pass
 
     def t_line_directive1(self, t):


### PR DESCRIPTION
Whitespace handling in parser doesn't use raw string for the token rule, but it should have.
It somehow works when not using raw string with python <3.13, but fails with python 3.13.
Use raw strings for all token regular expressions.