### PR TITLE
Add: --list-unused-strings to list the unused strings

### DIFF
--- a/nml/grfstrings.py
+++ b/nml/grfstrings.py
@@ -825,6 +825,8 @@ class Language:
     @type strings: C{dict} of
     """
 
+    used_strings = []
+
     def __init__(self, default):
         self.default = default
         self.langid = None
@@ -984,6 +986,9 @@ class Language:
         assert isinstance(string_id, str)
         assert string_id in self.strings
         assert lang_id == self.langid or self.langid == DEFAULT_LANGUAGE
+
+        if string_id not in Language.used_strings:
+            Language.used_strings.append(string_id)
 
         str_type = self.strings[string_id].get_type()
         parsed_string = ""
@@ -1291,3 +1296,10 @@ def read_lang_files(lang_dir, default_lang_file):
             continue
         parse_file(filename, False)
     langs.sort()
+
+
+def list_unused_strings():
+    for string in default_lang.strings:
+        if string in Language.used_strings:
+            continue
+        generic.print_warning(generic.Warning.GENERIC, 'String "{}" is unused'.format(string))

--- a/nml/main.py
+++ b/nml/main.py
@@ -90,6 +90,7 @@ def parse_cli(argv):
         allow_extra_zoom=True,
         allow_32bpp=True,
         disable_palette_validation=False,
+        list_unused_strings=False,
     )
     opt_parser.add_option("-d", "--debug", action="store_true", dest="debug", help="write the AST to stdout")
     opt_parser.add_option("-s", "--stack", action="store_true", dest="stack", help="Dump stack when an error occurs")
@@ -231,6 +232,9 @@ def parse_cli(argv):
         dest="disable_palette_validation",
         help="Disable palette validation for sprites",
     )
+    opt_parser.add_option(
+        "--list-unused-strings", action="store_true", dest="list_unused_strings", help="List unused strings"
+    )
 
     opts, args = opt_parser.parse_args(argv)
 
@@ -359,6 +363,9 @@ def main(argv):
     )
 
     input.close()
+
+    if opts.list_unused_strings:
+        grfstrings.list_unused_strings()
     sys.exit(ret)
 
 


### PR DESCRIPTION
When you have a huge language file it's easy to end up with useless strings when modifying grf source.
The translators then have to translate useless strings.

Add an nmlc option to list unused strings.