### PR TITLE
Add: Support for Action5 type 19 road waypoints

### DIFF
--- a/nml/actions/action5.py
+++ b/nml/actions/action5.py
@@ -83,6 +83,7 @@ action5_table = {
     "AIRPORT_PREVIEW": (0x16, 9, Action5BlockType.OFFSET),
     "RAILTYPE_TUNNELS": (0x17, 16, Action5BlockType.OFFSET),
     "OTTD_RECOLOUR": (0x18, 1, Action5BlockType.OFFSET),
+    "ROAD_WAYPOINTS": (0x19, 4, Action5BlockType.OFFSET),
 }
 
 


### PR DESCRIPTION
To support base graphics set road waypoints, [type `19`](https://newgrf-specs.tt-wiki.net/wiki/Action5#type) was added to Action5. This is for setting the 4 base road waypoint sprites.

This PR adds a new `ROAD_WAYPOINTS` type for `replacenew` to support this feature in nml.