### PR TITLE
Fix: Properly check number of varaction2 ranges

### DIFF
--- a/nml/actions/action2var.py
+++ b/nml/actions/action2var.py
@@ -1277,6 +1277,9 @@ def parse_varaction2(switch_block):
             )
         )
 
+    if len(varaction2.ranges) > 255:
+        raise generic.ScriptError("Too many ranges.", varaction2.pos)
+
     # Handle default result
     if switch_block.body.default is not None:
         # there is a default value


### PR DESCRIPTION
If a switch has more than 255 ranges, nmlc will trigger [this assert](https://github.com/OpenTTD/nml/blob/master/nml/output_base.py#L146).
Check earlier to report the error to the user in a more useful way.