### PR TITLE
Fix: [Actions] Install missing deps for PyPy

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -41,6 +41,19 @@ jobs:
         cache: 'pip'
         cache-dependency-path: setup.py
 
+    - name: Install dependencies (PyPy)
+      if: startsWith(matrix.python-version, 'pypy')
+      shell: bash
+      run: |
+        echo "::group::Update apt"
+        sudo apt-get update
+        echo "::endgroup::"
+
+        echo "::group::Install dependencies"
+        sudo apt-get install -y --no-install-recommends \
+          libjpeg-dev \
+          # EOF
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
`PyPy` needs `libjpeg-dev` to build `Pillow`.
`ubuntu-22.04` comes with `libjpeg-dev` preinstalled.
`ubuntu-24.04` doesn't come with `libjpeg-dev` preinstalled.
`ubuntu-latest` is transitioning from `ubuntu-22.04` to `ubuntu-24.04`.

Install `libjpeg-dev` manually for PyPy.