### PR TITLE
Fix #354: Improve length check for string literal properties

### DIFF
--- a/nml/actions/action0.py
+++ b/nml/actions/action0.py
@@ -611,13 +611,13 @@ def parse_property(prop_info, value_list, feature, id):
             if "string_literal" in prop_info and (
                 isinstance(value, expression.StringLiteral) or prop_info["string_literal"] != 4
             ):
-                # Parse non-string exprssions just like integers. User will have to take care of proper value.
+                # Parse non-string expressions just like integers. User will have to take care of proper value.
                 # This can be used to set a label (=string of length 4) to the value of a parameter.
                 if not isinstance(value, expression.StringLiteral):
                     raise generic.ScriptError(
                         "Value for property {:d} must be a string literal".format(prop_info["num"]), value.pos
                     )
-                if len(value.value) != prop_info["string_literal"]:
+                if grfstrings.get_string_size(value.value, False, True) != prop_info["string_literal"]:
                     raise generic.ScriptError(
                         "Value for property {:d} must be of length {:d}".format(
                             prop_info["num"], prop_info["string_literal"]

--- a/nml/expression/string_literal.py
+++ b/nml/expression/string_literal.py
@@ -13,7 +13,7 @@ You should have received a copy of the GNU General Public License along
 with NML; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
-from nml import generic
+from nml import generic, grfstrings
 
 from .base_expression import Expression, Type
 
@@ -37,7 +37,7 @@ class StringLiteral(Expression):
         return '"{}"'.format(self.value)
 
     def write(self, file, size):
-        assert len(self.value) == size
+        assert grfstrings.get_string_size(self.value, False, True) == size
         file.print_string(self.value, final_zero=False, force_ascii=True)
 
     def reduce(self, id_dicts=None, unknown_id_fatal=True):


### PR DESCRIPTION
Length check for string literal properties is dumb, it uses `len()` so `len('NML_')` is 4 and `len('\FFNML')` is 6.

Use `grfstrings.get_string_size()` so the length checks are done on actual length in bytes.