### PR TITLE
Fix: 'pip install nml' fails to build from source

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
-        python -m pip install -e .
+        python -m pip install .
 
     - name: Test
       run: make -C regression

--- a/nml/actions/real_sprite.py
+++ b/nml/actions/real_sprite.py
@@ -13,7 +13,11 @@ You should have received a copy of the GNU General Public License along
 with NML; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
-from PIL import Image
+try:
+    from PIL import Image
+except ImportError:
+    # Image is required only when using graphics
+    pass
 
 from nml import expression, generic
 from nml.actions import base_action

--- a/nml/main.py
+++ b/nml/main.py
@@ -53,6 +53,7 @@ try:
     from PIL import Image
 except ImportError:
     # Image is required only when using graphics
+    Image = None
     pass
 
 developmode = False  # Give 'nice' error message instead of a stack dump.
@@ -495,6 +496,11 @@ def nml(
             for sprite in action.sprite_list:
                 if sprite.is_empty:
                     continue
+
+                if not Image:
+                    generic.print_error("PIL (python-imaging) wasn't found, no support for using graphics")
+                    sys.exit(3)
+
                 sprite.validate_size()
 
                 file = sprite.file
@@ -524,10 +530,6 @@ def nml(
     if skip_sprite_processing:
         generic.clear_progress()
         return 0
-
-    if not Image and len(sprite_files) > 0:
-        generic.print_error("PIL (python-imaging) wasn't found, no support for using graphics")
-        sys.exit(3)
 
     used_palette = forced_palette
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "ply", "pillow>=3.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "ply", "pillow>=3.4"]
+requires = ["setuptools", "ply"]


### PR DESCRIPTION
When installing using `pip install nml`, if there's no wheel for a given python-os-arch it has to be built from source.
As build is done in isolated environment it fails with:
```
Processing /home/runner/work/nml/nml
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting Pillow>=3.4 (from nml==0.0.0)
  Using cached pillow-11.1.0-cp39-cp39-manylinux_2_28_x86_64.whl.metadata (9.1 kB)
Collecting ply (from nml==0.0.0)
  Using cached ply-3.11-py2.py3-none-any.whl.metadata (844 bytes)
Using cached pillow-11.1.0-cp39-cp39-manylinux_2_28_x86_64.whl (4.5 MB)
Using cached ply-3.11-py2.py3-none-any.whl (49 kB)
Building wheels for collected packages: nml
  Building wheel for nml (pyproject.toml): started
  Building wheel for nml (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Building wheel for nml (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [56 lines of output]
      fatal: No tags can describe '10c16c5b6de283e8d12131c039805960d31dbd06'.
      Try --always, or create some tags.
      Git checkout found but cannot determine its version. Error:  Command '['git', '-C', '/home/runner/work/nml/nml', 'describe', '--tags', '--long']' returned non-zero exit status 128.
      running bdist_wheel
      running build
      running build_py
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
        File "/opt/hostedtoolcache/Python/3.9.21/x64/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
          return _build_backend().build_wheel(
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 438, in build_wheel
          return _build(['bdist_wheel', '--dist-info-dir', str(metadata_directory)])
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 426, in _build
          return self._build_with_temp_dir(
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 407, in _build_with_temp_dir
          self.run_setup()
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 47, in <module>
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 186, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 983, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 1002, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/command/bdist_wheel.py", line 379, in run
          self.run_command("build")
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 339, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 1002, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/build.py", line 136, in run
          self.run_command(cmd_name)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 339, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-8b335_63/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 1002, in run_command
          cmd_obj.run()
        File "<string>", line 28, in run
        File "/home/runner/work/nml/nml/nml/parser.py", line 16, in <module>
          import ply.yacc as yacc
      ModuleNotFoundError: No module named 'ply'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for nml
Failed to build nml
ERROR: Failed to build installable wheels for some pyproject.toml based projects (nml)
```

Changed regression workflow so it also tests `pip install` (error log above is from this change).
Add a minimal `pyproject.toml` so isolated build knows the dependencies.

`ply` is required because we generate lexer and parser tables at build time.
`pillow` is required because it's indirectly imported (but not actually used) during table generation.
Requiring `pillow` at build time is annoying and was the reason for https://github.com/OpenTTD/nml/pull/353.