### PR TITLE
Fix 530e325f: 'gh' requires a git repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,15 @@ jobs:
           name: cibw-sdist
           path: dist/*.tar.gz
 
-  upload:
+      - name: Upload to github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} dist/*.tar.gz
+
+
+  publish:
+    name: Publish wheels and source distribution
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
@@ -57,10 +65,8 @@ jobs:
       - name: Publish wheel and source distribution
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           twine upload --username __token__ dist/*.whl dist/*.tar.gz
-          gh release upload ${{ github.event.release.tag_name }} dist/*.tar.gz
 
 
   release-windows:


### PR DESCRIPTION
I completely forgot `gh` required a git repository when rewritting the release workflow, luckily it failed after uploading to pypi, so I could manually attach the source package to the github release.

I had different options to fix the issue:
 - Insert the following block before `gh` command
 ```
        # "gh" only works automatically if run from a git repository.
        git init
        git remote add origin ${{ github.event.repository.html_url }}
```
 - Move the `gh` command to `build_sdist` job, with the advantage of quicker availability of the source package on github release.
 
I chose to move the command.