### PR TITLE
Add: Support for Action5 type 1A overlay rocks

### DIFF
--- a/nml/actions/action5.py
+++ b/nml/actions/action5.py
@@ -84,6 +84,7 @@ action5_table = {
     "RAILTYPE_TUNNELS": (0x17, 16, Action5BlockType.OFFSET),
     "OTTD_RECOLOUR": (0x18, 1, Action5BlockType.OFFSET),
     "ROAD_WAYPOINTS": (0x19, 4, Action5BlockType.OFFSET),
+    "OVERLAY_ROCKS": (0x1A, 95, Action5BlockType.OFFSET),
 }
 
 


### PR DESCRIPTION
To support snowy rocks, type 1A was added to Action5. This is for setting the 5 sets of 19 (normal, 1/4 snowy, 2/4 snowy, 3/4 snowy and 4/4 snowy) base rock overlay sprites.

This PR adds a new OVERLAY_ROCKS type for replacenew to support this feature in nml.