### PR TITLE
Fix: ALL_NORMAL_CARGO_CLASSES and ALL_CARGO_CLASSES did not include newer cargo classes.

### DIFF
--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -63,8 +63,8 @@ constant_numbers = {
     "CC_NON_POTABLE"  : 14,
     "CC_SPECIAL"      : 15,
     "NO_CARGO_CLASS"           : 0,
-    "ALL_NORMAL_CARGO_CLASSES" : 0x1FFF,
-    "ALL_CARGO_CLASSES"        : 0x9FFF,
+    "ALL_NORMAL_CARGO_CLASSES" : 0x7FFF,
+    "ALL_CARGO_CLASSES"        : 0xFFFF,
 
     # engine class
     "ENGINE_CLASS_STEAM"    : 0x00,


### PR DESCRIPTION
The wildcards `ALL_NORMAL_CARGO_CLASSES` and `ALL_CARGO_CLASSES` were not updated when `CC_POTABLE` and `CC_NON_POTABLE` were added.