### PR TITLE
Fix #367: Incorrect limits for House and Industry Tile

### DIFF
--- a/nml/actions/action0.py
+++ b/nml/actions/action0.py
@@ -197,9 +197,9 @@ used_ids = [
     BlockAllocation(0, 0xFFFE, "Station"),  # UINT16_MAX - 1
     BlockAllocation(0, 8, "Canal", False),
     BlockAllocation(0, 15, "Bridge", False),
-    BlockAllocation(0, 255, "House"),
+    BlockAllocation(0, 4095, "House"),
     BlockAllocation(0, -1, "Global", False),
-    BlockAllocation(0, 255, "Industry Tile"),
+    BlockAllocation(0, 254, "Industry Tile"),
     BlockAllocation(0, 127, "Industry"),
     BlockAllocation(0, 63, "Cargo"),
     BlockAllocation(0, -1, "Sound"),


### PR DESCRIPTION
https://github.com/OpenTTD/OpenTTD/pull/12288 increased House limit per newgrf to 4096, but nml was not updated. (BTW old value was off by one).

I also noticed an off by one error for Industry Tile (255 per newgrf).