### PR TITLE
Codefix: Remove unneeded "global"

### DIFF
--- a/nml/actions/action1.py
+++ b/nml/actions/action1.py
@@ -158,10 +158,10 @@ class SpritesetCollection(base_action.BaseAction):
 
 
 """
-The collection which was previoulsy used. add_to_action1 will try to reuse this
-collection as long as possible to reduce the duplication of sprites. As soon
-as a spriteset with a different feature or amount of sprites is added a new
-collection will be created.
+The list of collections per feature. add_to_action1 will try to reuse the
+last collection as long as possible to reduce the duplication of sprites. As soon
+as a spriteset with a different amount of sprites is added a new collection will
+be created.
 """
 spriteset_collections = {}
 
@@ -188,7 +188,6 @@ def add_to_action1(spritesets, feature, pos):
 
     actions = []
 
-    global spriteset_collections
     if feature not in spriteset_collections:
         spriteset_collections[feature] = [
             SpritesetCollection(feature, 0, len(real_sprite.parse_sprite_data(spritesets[0])))

--- a/nml/ast/grf.py
+++ b/nml/ast/grf.py
@@ -138,8 +138,6 @@ class GRF(base_statement.BaseStatement):
         self.version = self.version.reduce_constant()
         self.min_compatible_version = self.min_compatible_version.reduce_constant()
 
-        global param_stats
-
         param_num = 0
         for param in self.params:
             param.pre_process(expression.ConstantNumeric(param_num))


### PR DESCRIPTION
Flake8 7.2.0 introduced new checks and in result we get
```
Error: nml/actions/action1.py:191:5: F824 `global spriteset_collections` is unused: name is never assigned in scope
Error: nml/ast/grf.py:141:9: F824 `global param_stats` is unused: name is never assigned in scope
```

After some reading, these two `global` are not needed because we modify the actual object and not the reference to the object.

So make flake8 happy again and remove the useless `global`.