### PR TITLE
Add: Support for badge menu vertical ellipsis icon

### DIFF
--- a/nml/actions/action5.py
+++ b/nml/actions/action5.py
@@ -79,7 +79,7 @@ action5_table = {
     "AQUEDUCTS": (0x12, 8, Action5BlockType.OFFSET),
     "AUTORAIL": (0x13, 55, Action5BlockType.OFFSET),
     "FLAGS": (0x14, 36, Action5BlockType.OFFSET),
-    "OTTD_GUI": (0x15, 191, Action5BlockType.OFFSET),
+    "OTTD_GUI": (0x15, 192, Action5BlockType.OFFSET),
     "AIRPORT_PREVIEW": (0x16, 9, Action5BlockType.OFFSET),
     "RAILTYPE_TUNNELS": (0x17, 16, Action5BlockType.OFFSET),
     "OTTD_RECOLOUR": (0x18, 1, Action5BlockType.OFFSET),


### PR DESCRIPTION
Addition of the new badge menu vertical ellipsis icon increases the valid range for `OTTD_GUI`. Update `action5.py` to match this range.