### PR TITLE
Add: necessary properties in action0 in order to support bridges over station feature from OpenTTD 15.0-beta3

### DIFF
--- a/nml/actions/action0properties.py
+++ b/nml/actions/action0properties.py
@@ -818,6 +818,12 @@ def station_tile_flags(value):
     ]
 
 
+def station_minimum_bridge_height(value):
+    if not isinstance(value, Array):
+        raise generic.ScriptError("Flag list must be an array", value.pos)
+    return [VariableByteListProp(0x20, [[flags.reduce_constant().value for flags in value.values]], True)]
+
+
 # fmt: off
 properties[0x04] = {
     "class":                 {"size": 4, "num": 0x08, "first": None, "string_literal": 4},
@@ -843,6 +849,7 @@ properties[0x04] = {
     "name":                  {"size": 2, "num": (256, -1, 0x1C), "string": (256, 0xC5, 0xDC), "required": True},
     "classname":             {"size": 2, "num": (256, -1, 0x1D), "string": (256, 0xC4, 0xDC)},
     "tile_flags":            {"custom_function": station_tile_flags},  # = prop 1E
+    "minimum_bridge_height": {"custom_function": station_minimum_bridge_height},  # = prop 20
 }
 # fmt: on
 

--- a/nml/actions/action0properties.py
+++ b/nml/actions/action0properties.py
@@ -1694,4 +1694,10 @@ properties[0x14] = {
     # 11 (callback flags) is not set by user
     "general_flags":             {"size": 4, "num": 0x12},
     "cost_multipliers":          {"custom_function": lambda x: byte_sequence_list(x, 0x15, "Cost multipliers", 2)},
+    "minimum_bridge_height": {
+        "custom_function": array_for_station_properties(0x13, "Bridge heights", 1, lambda v : v)
+    },
+    "bridge_pillars_flags":  {
+        "custom_function": array_for_station_properties(0x14, "Flag", 1, invert_bridge_pillars_flags)
+    },
 }

--- a/nml/global_constants.py
+++ b/nml/global_constants.py
@@ -385,6 +385,16 @@ constant_numbers = {
     # station tiles
     "STAT_ALL_TILES"     : 0xFF,
 
+    # bridge pillar flags
+    "BRIDGE_PILLAR_CORNER_W"        : 0,
+    "BRIDGE_PILLAR_CORNER_S"        : 1,
+    "BRIDGE_PILLAR_CORNER_E"        : 2,
+    "BRIDGE_PILLAR_CORNER_N"        : 3,
+    "BRIDGE_PILLAR_EDGE_NE"         : 4,
+    "BRIDGE_PILLAR_EDGE_SE"         : 5,
+    "BRIDGE_PILLAR_EDGE_SW"         : 6,
+    "BRIDGE_PILLAR_EDGE_NW"         : 7,
+
     # house flags
     "HOUSE_FLAG_NOT_SLOPED"         : 1,
     "HOUSE_FLAG_ANIMATE"            : 5,


### PR DESCRIPTION
Allows to use bridges over stations feature for rail stations.
Do not contain necessary additions to allow same feature for road stops and other station types.
Remains compatible with OpenTTD 14.0 and older.