### PR TITLE
Change: move `black` options to `pyproject.toml`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -79,4 +79,4 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install black
-        black -l 120 --exclude "(ply|nml/actions/action2var_variables.py|nml/actions/action3_callbacks.py)" --check --diff nml
+        black --check --diff nml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 MAKE?=make
 PYTHON?=/usr/bin/env python3
-BLACK_OPTIONS=-l 120 --exclude 'action2var_variables.py|action3_callbacks.py|ply'
 
 .PHONY: regression test install extensions clean flake black
 
@@ -21,8 +20,8 @@ clean:
 	rm -f *.so
 
 flake:
-	$(PYTHON) -m black --check $(BLACK_OPTIONS) nml
+	$(PYTHON) -m black --check nml
 	$(PYTHON) -m flake8 nml
 
 black:
-	$(PYTHON) -m black $(BLACK_OPTIONS) nml
+	$(PYTHON) -m black nml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
 requires = ["setuptools", "ply"]
+
+[tool.black]
+line-length = 120
+exclude = 'action2var_variables.py|action3_callbacks.py|ply|setup.py'


### PR DESCRIPTION
`black` supports storing configuration in `pyproject.toml`. This pull request moves the existing command-line options to the file.

I think this change has a few advantages:
* The current command-line options are duplicated in two places (Makefile and Github Actions), the `pyproject.toml` is a unified place.
* By putting the configuration in `pyproject.toml`, running `black .` anywhere within the repository would produce correct results. This guards against a lot of surprises.
    * Caveat: running `black <a file name that's excluded>` still formats what should not be formatted. This is a special case that's no worse than before though.

I also included `setup.py` in the excludes just in case people run `black .` instead of `black nml` in the repository root.