### PR TITLE
Add: FEAT_AIRCRAFT flight_state variable (varE2)

### DIFF
--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -212,6 +212,7 @@ varact2vars_aircraft = {
     'max_speed'           : {'var': 0x98, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x3939, 0x1000)},
     'current_speed'       : {'var': 0xB4, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x3939, 0x1000)},
     'current_max_speed'   : {'var': 0x4C, 'start': 0, 'size': 16, 'value_function': value_mul_div(0x3939, 0x1000)},
+    'flight_state'        : {'var': 0xE2, 'start': 0, 'size':  8},
     'vehicle_is_in_depot' : {'var': 0xE6, 'start': 0, 'size':  8, 'value_function': value_equals(0)},
 }
 


### PR DESCRIPTION
Some aircraft NewGRF use varE2 to customise takeoff and landing (via `#define flight_state() (var[0xE2, 0, 0xFF])` or other method).
It should be simpler to just have the variable directly available in NML.