### PR TITLE
Change: Include .nml, .lng, and custom_tags.txt files in -M output

### DIFF
--- a/nml/grfstrings.py
+++ b/nml/grfstrings.py
@@ -289,7 +289,7 @@ special_commands = [
 ]
 
 
-def read_extra_commands(custom_tags_file):
+def read_extra_commands(custom_tags_file, dependencies: list[str]):
     """
     @param custom_tags_file: Filename of the custom tags file.
     @type  custom_tags_file: C{str}
@@ -298,6 +298,7 @@ def read_extra_commands(custom_tags_file):
         # Failed to open custom_tags.txt, ignore this
         return
     line_no = 0
+    dependencies.append(custom_tags_file)
     with open(generic.find_file(custom_tags_file), "r", encoding="utf-8") as fh:
         for line in fh:
             line_no += 1
@@ -1267,7 +1268,7 @@ def parse_file(filename, default):
             langs.append((lang.langid, lang))
 
 
-def read_lang_files(lang_dir, default_lang_file):
+def read_lang_files(lang_dir, default_lang_file, dependencies: list[str]):
     """
     Read the language files containing the translations for string constants
     used in the NML specification.
@@ -1289,10 +1290,13 @@ def read_lang_files(lang_dir, default_lang_file):
             'Default language file "{}" doesn\'t exist'.format(os.path.join(lang_dir, default_lang_file)),
         )
         return
+    dependencies.append(lang_dir + os.sep + default_lang_file)
     parse_file(lang_dir + os.sep + default_lang_file, True)
+    dependencies.append(lang_dir)
     for filename in glob.glob(lang_dir + os.sep + "*.lng"):
         if filename.endswith(default_lang_file):
             continue
+        dependencies.append(filename)
         parse_file(filename, False)
     langs.sort()
 

--- a/nml/main.py
+++ b/nml/main.py
@@ -105,7 +105,7 @@ def parse_cli(argv):
         dest="dep_check",
         help=(
             "output a rule suitable for make describing"
-            " the graphics dependencies of the main grf file (requires input file or --grf)"
+            " the dependencies of the main grf file (requires input file or --grf)"
         ),
     )
     opt_parser.add_option(
@@ -265,11 +265,13 @@ def main(argv):
     if opts.stack:
         developmode = True
 
-    grfstrings.read_extra_commands(opts.custom_tags)
+    dependencies = []
+
+    grfstrings.read_extra_commands(opts.custom_tags, dependencies)
 
     generic.print_progress("Reading lang ...")
 
-    grfstrings.read_lang_files(opts.lang_dir, opts.default_lang)
+    grfstrings.read_lang_files(opts.lang_dir, opts.default_lang, dependencies)
 
     generic.clear_progress()
 
@@ -307,6 +309,7 @@ def main(argv):
     if input_filename is None:
         input = sys.stdin
     else:
+        dependencies.append(input_filename)
         input = codecs.open(generic.find_file(input_filename), "r", "utf-8")
         # Only append an output grf name, if no output is given, also not implicitly via -M
         if not opts.outputfile_given and not outputs:
@@ -352,6 +355,7 @@ def main(argv):
         opts.md5_filename,
         opts.debug_parser,
         opts.disable_palette_validation,
+        dependencies,
     )
 
     input.close()
@@ -377,6 +381,7 @@ def nml(
     md5_filename,
     debug_parser,
     disable_palette_validation,
+    dependencies,
 ):
     """
     Compile an NML file.
@@ -405,6 +410,9 @@ def nml(
     @param md5_filename: Filename to use for writing the md5 sum of the grf file.
                          C{None} if the file should not be written.
     @type  md5_filename: C{str} or C{None}
+
+    @param dependencies: List of lang/config file dependencies.
+    @type  dependencies: C{List}
     """
     generic.OnlyOnce.clear()
 
@@ -510,6 +518,10 @@ def nml(
     for outputfile in outputfiles:
         if isinstance(outputfile, output_dep.OutputDEP):
             with outputfile:
+                # Dependencies from outside world
+                for dep in dependencies:
+                    outputfile.write(dep)
+                # Sprite dependencies discovered during build
                 for f in sprite_files:
                     if f[0] is not None:
                         outputfile.write(f[0])


### PR DESCRIPTION
Depfile output is useful, but it's bad form for it to be incomplete. Changes to input `.nml` file, the `.lng` files, the directory globbed to discover `.lng` files, and (if it exists) `custom_tags.txt` should all trigger builds, so include them in the `-M` output.

A remaining corner case is that the first-time creation of `custom_tags.txt` is not caught.