### PR TITLE
Add: Variable for when a train is driving backwards

### DIFF
--- a/nml/actions/action2var_variables.py
+++ b/nml/actions/action2var_variables.py
@@ -167,6 +167,7 @@ varact2vars_vehicles = {
     'vehicle_is_not_powered'           : {'var': 0xFE, 'start':  6, 'size':  1},
     'vehicle_is_reversed'              : {'var': 0xFE, 'start':  8, 'size':  1},
     'built_during_preview'             : {'var': 0xFE, 'start': 10, 'size':  1},
+    'train_is_driving_backwards'       : {'var': 0xFE, 'start': 11, 'size':  1},
 }
 
 # Vehicle-type-specific variables


### PR DESCRIPTION
## Description

Add a variable to read `VehicleFlag::DrivingBackwards` in https://github.com/OpenTTD/OpenTTD/pull/15379

The intent of this variable is for NewGRF authors to control sprites of trains which drive backwards, such as headlights and tail lamps.

## Limitations

* Untested