### PR TITLE
Fix: [Actions] update macos images used for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        # macos-latest (macos-15) is apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Release workflow partly failed because it was still using `macos-13`, so it skipped upload to pypi.