### PR TITLE
Add: Missing features to random switch.

### DIFF
--- a/nml/actions/action2random.py
+++ b/nml/actions/action2random.py
@@ -90,7 +90,7 @@ random_types = {
     0x0A: {"SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 16, "triggers": False}},
     0x0B: {},
     0x0C: {},
-    0x0D: {},
+    0x0D: {"SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 16, "triggers": False}},
     0x0E: {},
     0x0F: {"SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 8, "triggers": False}},
     0x10: {"SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 2, "triggers": False}},
@@ -100,6 +100,11 @@ random_types = {
     },
     0x12: {"SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 2, "triggers": False}},
     0x13: {"SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 2, "triggers": False}},
+    0x14: {
+        "SELF": {"type": 0x80, "param": 0, "first_bit": 0, "num_bits": 16, "triggers": True},
+        "TILE": {"type": 0x80, "param": 0, "first_bit": 16, "num_bits": 8, "triggers": True},
+    },
+    0x15: {},
 }
 
 


### PR DESCRIPTION
When road stops and badges were added the data for random action 2 was not.

Add TILE and SELF for road stops matching behaviour in stations. However road stops have 8 bits in TILE when stations have only 4 (based on https://newgrf-specs.tt-wiki.net/wiki/RandomAction2#Triggers)

Add empty dictionary for badges to generate pretty errors instead of internal ones.