### PR TITLE
Fix: Max number of spritesets would not error appropriately

### DIFF
--- a/nml/actions/action2layout.py
+++ b/nml/actions/action2layout.py
@@ -668,9 +668,10 @@ class StationSpritesetVar10Map:
                     spriteset.set_action2(real_action2, feature)
                 ref = expression.SpriteGroupRef(spriteset.name, [], None, spriteset.get_action2(feature))
             else:
-                if spriteset > len(custom_spritesets):
+                try:
+                    ref = custom_spritesets[spriteset]
+                except IndexError:
                     raise generic.ScriptError("Index out of range")
-                ref = custom_spritesets[spriteset]
             # Skip default result
             if ref == default:
                 continue


### PR DESCRIPTION
In python list indexes are in range 0..(len(list) - 1).
Therefore custom_spritesets[len(custom_spritesets)] will fail.

Replace the invalid `>` with `>=`.