### PR TITLE
Codefix: In error message `of` was used instead of `or`

### DIFF
--- a/nml/ast/sort_vehicles.py
+++ b/nml/ast/sort_vehicles.py
@@ -44,7 +44,7 @@ class SortVehicles(base_statement.BaseStatement):
             isinstance(x, expression.ConstantNumeric) for x in self.vehid_list.values
         ):
             raise generic.ScriptError(
-                "Second parameter is not an array of one of the items in it could not be reduced to a constant number",
+                "Second parameter is not an array or one of the items in it could not be reduced to a constant number",
                 self.pos,
             )
 


### PR DESCRIPTION
The error message is wrong.
Simply fix it.
I thought it was already fixed for some reason.