### PR TITLE
Change: increase industry tile ID limit

### DIFF
--- a/nml/actions/action0.py
+++ b/nml/actions/action0.py
@@ -199,7 +199,7 @@ used_ids = [
     BlockAllocation(0, 15, "Bridge", False),
     BlockAllocation(0, 4095, "House"),
     BlockAllocation(0, -1, "Global", False),
-    BlockAllocation(0, 254, "Industry Tile"),
+    BlockAllocation(0, 511, "Industry Tile"),
     BlockAllocation(0, 127, "Industry"),
     BlockAllocation(0, 63, "Cargo"),
     BlockAllocation(0, -1, "Sound"),


### PR DESCRIPTION
Industry tile ID limit increased from 254 to 511 in OpenTTD https://github.com/OpenTTD/OpenTTD/pull/12183